### PR TITLE
Proposal: Use GCC 8 for development on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Toolchain
 ---------
 
   * Language: C++17
-  * Compilers: MSVC 14.1 (i.e., Visual Studio 2017), GCC 6.3
+  * Compilers: MSVC 14.1 (i.e., Visual Studio 2017), GCC 8
   * Build tool: CMake >= 3.9
   * API doc generator: Doxygen >= 1.8
 


### PR DESCRIPTION
I propose we use GCC 8 as our development platform on Linux. It is rather bleeding-edge right now, but I think there are good reasons to use it:

  * It is the first GCC version with full C++17 support, which is the most important argument to me, at least.
  * By the time the project ends and we go open source, it will be two years old.
  * We are offering a C API on top of our C++ API. This can be used by anyone, even people who are stuck with ancient compilers, so we can afford to be a bit fancy in our C++ API.

It is easy enough to find GCC 8 packages for most distros that I don't see that as a problem.