### PR TITLE
Fix GCC warnings on Linux and move fmilib includes to separate header

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ set(publicHeaders
 )
 set(privateHeaders
     "error.hpp"
+    "fmi/fmilib.h"
     "fmi/glue.hpp"
     "fmi/windows.hpp"
     "log/logger.hpp"
@@ -54,7 +55,12 @@ set(allSources ${publicHeadersFull} ${privateHeadersFull} ${sources})
 
 add_library(csecorecpp ${allSources})
 target_compile_features(csecorecpp PUBLIC "cxx_std_17")
-target_include_directories(csecorecpp PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>")
+target_include_directories(csecorecpp
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>"
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+)
 target_link_libraries(csecorecpp
     PUBLIC
         ${FMILibrary_LIBRARIES}

--- a/src/cpp/cse/fmi/fmilib.h
+++ b/src/cpp/cse/fmi/fmilib.h
@@ -1,0 +1,27 @@
+/**
+ *  \file
+ *  Includes the FMI Library header, locally disabling some compilation
+ *  warnings for it.
+ */
+#ifndef CSE_FMI_FMILIB_H
+#define CSE_FMI_FMILIB_H
+
+#ifdef _MSC_VER
+#   pragma warning(push, 0)
+#endif
+#ifdef __GNUC__
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wunused-function"
+#   pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
+#include <fmilib.h>
+
+#ifdef _MSC_VER
+#   pragma warning(pop)
+#endif
+#ifdef __GNUC__
+#   pragma GCC diagnostic pop
+#endif
+
+#endif // header guard

--- a/src/cpp/cse/fmi/glue.hpp
+++ b/src/cpp/cse/fmi/glue.hpp
@@ -5,14 +5,7 @@
 #ifndef CSE_FMI_GLUE_HPP
 #define CSE_FMI_GLUE_HPP
 
-#ifdef _MSC_VER
-#   pragma warning(push, 0)
-#endif
-#include <fmilib.h>
-#ifdef _MSC_VER
-#   pragma warning(pop)
-#endif
-
+#include "cse/fmi/fmilib.h"
 #include <cse/model.hpp>
 
 

--- a/src/cpp/fmi_importer.cpp
+++ b/src/cpp/fmi_importer.cpp
@@ -12,15 +12,8 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
-#ifdef _MSC_VER
-#   pragma warning(push, 0)
-#endif
-#include <fmilib.h>
-#ifdef _MSC_VER
-#   pragma warning(pop)
-#endif
-
 #include "cse/error.hpp"
+#include "cse/fmi/fmilib.h"
 #include <cse/fmi/v1/fmu.hpp>
 #include <cse/fmi/v2/fmu.hpp>
 #include "cse/log/logger.hpp"

--- a/src/cpp/fmi_v1_fmu.cpp
+++ b/src/cpp/fmi_v1_fmu.cpp
@@ -13,16 +13,9 @@
 
 #include <gsl/gsl_util>
 
-#ifdef _MSC_VER
-#   pragma warning(push, 0)
-#endif
-#include <fmilib.h>
-#ifdef _MSC_VER
-#   pragma warning(pop)
-#endif
-
 #include "cse/error.hpp"
 #include <cse/exception.hpp>
+#include "cse/fmi/fmilib.h"
 #include "cse/fmi/glue.hpp"
 #include <cse/fmi/importer.hpp>
 #include "cse/log/logger.hpp"

--- a/src/cpp/fmi_v2_fmu.cpp
+++ b/src/cpp/fmi_v2_fmu.cpp
@@ -13,16 +13,9 @@
 
 #include <gsl/gsl_util>
 
-#ifdef _MSC_VER
-#   pragma warning(push, 0)
-#endif
-#include <fmilib.h>
-#ifdef _MSC_VER
-#   pragma warning(pop)
-#endif
-
 #include "cse/error.hpp"
 #include <cse/exception.hpp>
+#include "cse/fmi/fmilib.h"
 #include "cse/fmi/glue.hpp"
 #include <cse/fmi/importer.hpp>
 #include "cse/log/logger.hpp"


### PR DESCRIPTION
This takes care of some GCC warnings (which are treated as errors with our strict compiler settings) about unused functions and parameters in `fmilib.h`. It is becoming cumbersome to locally disable the various compiler-specific diagnostics in each and every file that includes this header, so I also created a wrapper header where this can be done once and for all.