### PR TITLE
Clang-format all existing code

### DIFF
--- a/include/cse.h
+++ b/include/cse.h
@@ -71,8 +71,7 @@ typedef enum
 
     /// ZIP file error.
     CSE_ERRC_ZIP_ERROR,
-}
-cse_errc;
+} cse_errc;
 
 
 /**

--- a/include/cse/async_slave.hpp
+++ b/include/cse/async_slave.hpp
@@ -6,9 +6,12 @@
 #define CSE_ASYNC_SLAVE_HPP
 
 #include <string>
-#include <gsl/span>
+
 #include <boost/fiber/future/future.hpp>
+#include <gsl/span>
+
 #include <cse/model.hpp>
+
 
 namespace cse
 {
@@ -64,8 +67,7 @@ public:
         time_point startTime,
         time_point stopTime,
         bool adaptiveStepSize,
-        double relativeTolerance)
-        = 0;
+        double relativeTolerance) = 0;
 
     /**
      *  Informs the slave that the initialisation stage ends and the
@@ -90,8 +92,7 @@ public:
      */
     virtual boost::fibers::future<bool> do_step(
         time_point currentT,
-        time_duration deltaT)
-        = 0;
+        time_duration deltaT) = 0;
 
     /// Result type for `get_variables()`.
     struct variable_values
@@ -133,8 +134,7 @@ public:
         gsl::span<const variable_index> realVariables,
         gsl::span<const variable_index> integerVariables,
         gsl::span<const variable_index> booleanVariables,
-        gsl::span<const variable_index> stringVariables)
-        = 0;
+        gsl::span<const variable_index> stringVariables) = 0;
 
     /**
      *  Sets variable values.
@@ -162,10 +162,9 @@ public:
         gsl::span<const variable_index> booleanVariables,
         gsl::span<const bool> booleanValues,
         gsl::span<const variable_index> stringVariables,
-        gsl::span<const std::string> stringValues)
-        = 0;
+        gsl::span<const std::string> stringValues) = 0;
 };
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/include/cse/config.hpp
+++ b/include/cse/config.hpp
@@ -13,7 +13,9 @@
  *
  *  \ingroup csecore
  */
-namespace cse { }
+namespace cse
+{
+}
 
 
 #endif // header guard

--- a/include/cse/detail/macros.hpp
+++ b/include/cse/detail/macros.hpp
@@ -12,15 +12,23 @@
  *  \param EnumName The `enum class` type.
  *  \param BaseType The base type, usually `int`.
  */
-#define CSE_DETAIL_DEFINE_BITWISE_ENUM_OPERATORS(EnumName, BaseType) \
-    constexpr EnumName operator|(EnumName a, EnumName b) noexcept { \
-        return static_cast<EnumName>(static_cast<BaseType>(a) | static_cast<BaseType>(b)); } \
-    constexpr EnumName operator&(EnumName a, EnumName b) noexcept { \
-        return static_cast<EnumName>(static_cast<BaseType>(a) & static_cast<BaseType>(b)); } \
-    constexpr EnumName& operator|=(EnumName& a, EnumName b) noexcept { \
-        return *reinterpret_cast<EnumName*>(&(*reinterpret_cast<BaseType*>(&a) |= static_cast<BaseType>(b))); } \
-    constexpr EnumName& operator&=(EnumName& a, EnumName b) noexcept { \
-        return *reinterpret_cast<EnumName*>(&(*reinterpret_cast<BaseType*>(&a) &= static_cast<BaseType>(b))); } \
+#define CSE_DETAIL_DEFINE_BITWISE_ENUM_OPERATORS(EnumName, BaseType)                                          \
+    constexpr EnumName operator|(EnumName a, EnumName b) noexcept                                             \
+    {                                                                                                         \
+        return static_cast<EnumName>(static_cast<BaseType>(a) | static_cast<BaseType>(b));                    \
+    }                                                                                                         \
+    constexpr EnumName operator&(EnumName a, EnumName b) noexcept                                             \
+    {                                                                                                         \
+        return static_cast<EnumName>(static_cast<BaseType>(a) & static_cast<BaseType>(b));                    \
+    }                                                                                                         \
+    constexpr EnumName& operator|=(EnumName& a, EnumName b) noexcept                                          \
+    {                                                                                                         \
+        return *reinterpret_cast<EnumName*>(&(*reinterpret_cast<BaseType*>(&a) |= static_cast<BaseType>(b))); \
+    }                                                                                                         \
+    constexpr EnumName& operator&=(EnumName& a, EnumName b) noexcept                                          \
+    {                                                                                                         \
+        return *reinterpret_cast<EnumName*>(&(*reinterpret_cast<BaseType*>(&a) &= static_cast<BaseType>(b))); \
+    }                                                                                                         \
     constexpr bool operator!(EnumName a) { return !static_cast<BaseType>(a); }
 
 #endif // header guard

--- a/include/cse/event_loop.hpp
+++ b/include/cse/event_loop.hpp
@@ -11,7 +11,6 @@
 #include <cse/detail/macros.hpp>
 
 
-
 namespace cse
 {
 
@@ -25,11 +24,12 @@ class oneshot_event_handler;
 
 
 /// Socket I/O event type bitmask.
-enum class socket_event_type {
+enum class socket_event_type
+{
     none = 0,
 
     /// A socket becomes ready for reading.
-    read  = 1,
+    read = 1,
 
     /// A socket becomes ready for writing.
     write = 2
@@ -233,5 +233,5 @@ public:
 };
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/include/cse/exception.hpp
+++ b/include/cse/exception.hpp
@@ -75,7 +75,7 @@ public:
     explicit error(std::error_code ec)
         : std::runtime_error(ec.message())
         , code_(ec)
-    { }
+    {}
 
     /**
      *  Constructs an exception with the given error code and an additional
@@ -88,7 +88,7 @@ public:
     error(std::error_code ec, const std::string& msg)
         : std::runtime_error(ec.message() + ": " + msg)
         , code_(ec)
-    { }
+    {}
 
     /// Returns an error code.
     const std::error_code& code() const noexcept { return code_; }
@@ -113,21 +113,24 @@ public:
     /// Constructs an exception with a default error message.
     nonfatal_bad_value()
         : error(make_error_code(errc::nonfatal_bad_value))
-    { }
+    {}
 
     /// Constructs an exception with a custom error message.
     explicit nonfatal_bad_value(const std::string& msg)
         : error(make_error_code(errc::nonfatal_bad_value), msg)
-    { }
+    {}
 };
 
 
-} // namespace
+} // namespace cse
 
 
 namespace std
 {
-    // Enable implicit conversions from errc to std::error_condition.
-    template<> struct is_error_condition_enum<cse::errc> : public true_type { };
-}
+// Enable implicit conversions from errc to std::error_condition.
+template<>
+struct is_error_condition_enum<cse::errc> : public true_type
+{
+};
+} // namespace std
 #endif // header guard

--- a/include/cse/fmi/fmu.hpp
+++ b/include/cse/fmi/fmu.hpp
@@ -6,6 +6,7 @@
 #define CSE_FMI_FMU_HPP
 
 #include <memory>
+
 #include <cse/model.hpp>
 #include <cse/slave.hpp>
 
@@ -49,7 +50,7 @@ public:
 
     /// A description of this FMU.
     virtual std::shared_ptr<const cse::model_description>
-        model_description() const = 0;
+    model_description() const = 0;
 
     /// Creates a co-simulation slave instance of this FMU.
     virtual std::shared_ptr<slave_instance> instantiate_slave() = 0;
@@ -57,7 +58,7 @@ public:
     /// The `fmi::importer` which was used to import this FMU.
     virtual std::shared_ptr<fmi::importer> importer() const = 0;
 
-    virtual ~fmu() { }
+    virtual ~fmu() {}
 };
 
 
@@ -73,9 +74,10 @@ public:
         return *(fmu()->model_description());
     }
 
-    virtual ~slave_instance() { }
+    virtual ~slave_instance() {}
 };
 
 
-}} // namespace
+} // namespace fmi
+} // namespace cse
 #endif // header guard

--- a/include/cse/fmi/importer.hpp
+++ b/include/cse/fmi/importer.hpp
@@ -20,7 +20,10 @@ struct jm_callbacks;
 namespace cse
 {
 
-namespace utility { class temp_dir; }
+namespace utility
+{
+class temp_dir;
+}
 
 
 namespace fmi
@@ -143,5 +146,6 @@ private:
 };
 
 
-}} // namespace
+} // namespace fmi
+} // namespace cse
 #endif // header guard

--- a/include/cse/fmi/v1/fmu.hpp
+++ b/include/cse/fmi/v1/fmu.hpp
@@ -24,7 +24,10 @@ namespace fmi
 {
 
 #ifdef _WIN32
-namespace detail { class additional_path; }
+namespace detail
+{
+class additional_path;
+}
 #endif
 
 namespace v1
@@ -61,7 +64,7 @@ public:
     fmi::fmi_version fmi_version() const override;
 
     std::shared_ptr<const cse::model_description>
-        model_description() const override;
+    model_description() const override;
 
     std::shared_ptr<fmi::slave_instance> instantiate_slave() override
     {
@@ -176,9 +179,11 @@ private:
 
     std::string instanceName_;
     time_point startTime_ = 0.0;
-    time_point stopTime_  = eternity;
+    time_point stopTime_ = eternity;
 };
 
 
-}}} // namespace
+} // namespace v1
+} // namespace fmi
+} // namespace cse
 #endif // header guard

--- a/include/cse/fmi/v2/fmu.hpp
+++ b/include/cse/fmi/v2/fmu.hpp
@@ -24,7 +24,10 @@ namespace fmi
 {
 
 #ifdef _WIN32
-namespace detail { class additional_path; }
+namespace detail
+{
+class additional_path;
+}
 #endif
 
 namespace v2
@@ -61,7 +64,7 @@ public:
     fmi::fmi_version fmi_version() const override;
 
     std::shared_ptr<const cse::model_description>
-        model_description() const override;
+    model_description() const override;
 
     std::shared_ptr<fmi::slave_instance> instantiate_slave() override
     {
@@ -178,5 +181,7 @@ private:
 };
 
 
-}}} // namespace
+} // namespace v2
+} // namespace fmi
+} // namespace cse
 #endif // header guard

--- a/include/cse/hello_world.hpp
+++ b/include/cse/hello_world.hpp
@@ -38,5 +38,5 @@ constexpr int get_ultimate_answer() noexcept
 }
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/include/cse/lib_info.hpp
+++ b/include/cse/lib_info.hpp
@@ -17,5 +17,5 @@ namespace cse
 constexpr const char* library_short_name = "cse-core";
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/include/cse/libevent.hpp
+++ b/include/cse/libevent.hpp
@@ -6,6 +6,7 @@
 #define CSE_LIBEVENT_HPP
 
 #include <memory>
+
 #include <cse/event_loop.hpp>
 
 
@@ -23,5 +24,5 @@ namespace cse
 std::unique_ptr<event_loop> make_libevent_event_loop();
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/include/cse/log.hpp
+++ b/include/cse/log.hpp
@@ -23,5 +23,6 @@ enum class level
 };
 
 
-}} // namespace
+} // namespace log
+} // namespace cse
 #endif // header guard

--- a/include/cse/model.hpp
+++ b/include/cse/model.hpp
@@ -41,7 +41,13 @@ using variable_index = std::uint32_t;
 
 
 /// Variable data types.
-enum class variable_type { real, integer, boolean, string };
+enum class variable_type
+{
+    real,
+    integer,
+    boolean,
+    string
+};
 
 
 /// Variable causalities.  These correspond to FMI causality definitions.
@@ -70,11 +76,11 @@ enum variable_variability
 constexpr const char* to_text(variable_type v)
 {
     switch (v) {
-        case variable_type::real:    return "real";
+        case variable_type::real: return "real";
         case variable_type::integer: return "integer";
         case variable_type::boolean: return "boolean";
-        case variable_type::string:  return "string";
-        default:                     return nullptr;
+        case variable_type::string: return "string";
+        default: return nullptr;
     }
 }
 
@@ -83,12 +89,12 @@ constexpr const char* to_text(variable_type v)
 constexpr const char* to_text(variable_causality v)
 {
     switch (v) {
-        case variable_causality::parameter:            return "parameter";
+        case variable_causality::parameter: return "parameter";
         case variable_causality::calculated_parameter: return "calculated_parameter";
-        case variable_causality::input:                return "input";
-        case variable_causality::output:               return "output";
-        case variable_causality::local:                return "local";
-        default:                                       return nullptr;
+        case variable_causality::input: return "input";
+        case variable_causality::output: return "output";
+        case variable_causality::local: return "local";
+        default: return nullptr;
     }
 }
 
@@ -97,12 +103,12 @@ constexpr const char* to_text(variable_causality v)
 constexpr const char* to_text(variable_variability v)
 {
     switch (v) {
-        case variable_variability::constant:   return "constant";
-        case variable_variability::fixed:      return "fixed";
-        case variable_variability::tunable:    return "tunable";
-        case variable_variability::discrete:   return "discrete";
+        case variable_variability::constant: return "constant";
+        case variable_variability::fixed: return "fixed";
+        case variable_variability::tunable: return "tunable";
+        case variable_variability::discrete: return "discrete";
         case variable_variability::continuous: return "continuous";
-        default:                               return nullptr;
+        default: return nullptr;
     }
 }
 
@@ -183,5 +189,5 @@ struct model_description
 };
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/include/cse/slave.hpp
+++ b/include/cse/slave.hpp
@@ -6,8 +6,11 @@
 #define CSE_SLAVE_HPP
 
 #include <string>
+
 #include <gsl/span>
+
 #include <cse/model.hpp>
+
 
 namespace cse
 {
@@ -42,7 +45,7 @@ namespace cse
 class slave
 {
 public:
-    virtual ~slave() { }
+    virtual ~slave() {}
 
     /// Returns a model description.
     virtual cse::model_description model_description() const = 0;
@@ -225,5 +228,5 @@ public:
 };
 
 
-}
+} // namespace cse
 #endif // header guard

--- a/src/cpp/cse/error.hpp
+++ b/src/cpp/cse/error.hpp
@@ -62,14 +62,13 @@
  *
  *  \param[in] test An expression which can be implicitly converted to `bool`.
  */
-#define CSE_INPUT_CHECK(test)                                                  \
-    do {                                                                       \
-        if (!(test)) {                                                         \
-            throw std::invalid_argument(                                       \
-                std::string(__FUNCTION__)                                      \
-                + ": Input requirement not satisfied: " #test);                \
-        }                                                                      \
-    } while(false)
+#define CSE_INPUT_CHECK(test)                                                             \
+    do {                                                                                  \
+        if (!(test)) {                                                                    \
+            throw std::invalid_argument(                                                  \
+                std::string(__FUNCTION__) + ": Input requirement not satisfied: " #test); \
+        }                                                                                 \
+    } while (false)
 
 /**
  *  \def    CSE_PANIC()
@@ -80,8 +79,10 @@
  *  the macro is invoked.  The program is terminated by calling
  *  `std::terminate()`.
  */
-#define CSE_PANIC() \
-    do { ::cse::detail::panic(__FILE__, __LINE__, nullptr); } while(false)
+#define CSE_PANIC()                                        \
+    do {                                                   \
+        ::cse::detail::panic(__FILE__, __LINE__, nullptr); \
+    } while (false)
 
 /**
  *  \def    CSE_PANIC_M(message)
@@ -92,15 +93,17 @@
  *  the macro is invoked, in addition to the text provided in `message`.
  *  The program is terminated by calling `std::terminate()`.
  */
-#define CSE_PANIC_M(message) \
-    do { ::cse::detail::panic(__FILE__, __LINE__, message); } while(false)
+#define CSE_PANIC_M(message)                               \
+    do {                                                   \
+        ::cse::detail::panic(__FILE__, __LINE__, message); \
+    } while (false)
 
 
 namespace cse
 {
 namespace detail
 {
-    [[noreturn]] void panic(const char* file, int line, const char* msg) noexcept;
+[[noreturn]] void panic(const char* file, int line, const char* msg) noexcept;
 }
 
 
@@ -132,5 +135,5 @@ inline std::system_error make_system_error(const std::string& msg) noexcept
 }
 
 
-} // namespace
+} // namespace cse
 #endif // header guard

--- a/src/cpp/cse/fmi/fmilib.h
+++ b/src/cpp/cse/fmi/fmilib.h
@@ -7,21 +7,21 @@
 #define CSE_FMI_FMILIB_H
 
 #ifdef _MSC_VER
-#   pragma warning(push, 0)
+#    pragma warning(push, 0)
 #endif
 #ifdef __GNUC__
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wunused-function"
-#   pragma GCC diagnostic ignored "-Wunused-parameter"
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-function"
+#    pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #include <fmilib.h>
 
 #ifdef _MSC_VER
-#   pragma warning(pop)
+#    pragma warning(pop)
 #endif
 #ifdef __GNUC__
-#   pragma GCC diagnostic pop
+#    pragma GCC diagnostic pop
 #endif
 
 #endif // header guard

--- a/src/cpp/cse/fmi/glue.hpp
+++ b/src/cpp/cse/fmi/glue.hpp
@@ -54,5 +54,6 @@ variable_description to_variable_description(fmi1_import_variable_t* fmiVariable
 variable_description to_variable_description(fmi2_import_variable_t* fmiVariable);
 
 
-}} // namespace
+} // namespace fmi
+} // namespace cse
 #endif // header guard

--- a/src/cpp/cse/fmi/windows.hpp
+++ b/src/cpp/cse/fmi/windows.hpp
@@ -6,9 +6,8 @@
 #define CSE_FMI_WINDOWS_HPP
 
 #ifdef _WIN32
-
-#include <filesystem>
-#include <string>
+#    include <filesystem>
+#    include <string>
 
 
 namespace cse
@@ -62,6 +61,7 @@ private:
 std::filesystem::path fmu_binaries_dir(const std::filesystem::path& baseDir);
 
 
-}} // namespace
+} // namespace fmi
+} // namespace cse
 #endif // _WIN32
 #endif // header guard

--- a/src/cpp/cse/log/logger.hpp
+++ b/src/cpp/cse/log/logger.hpp
@@ -21,7 +21,6 @@ namespace log
 BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
     logger,
     boost::log::sources::severity_logger_mt<level>)
-
-
-}} // namespace
+}
+} // namespace cse
 #endif // header guard

--- a/src/cpp/cse/utility/filesystem.hpp
+++ b/src/cpp/cse/utility/filesystem.hpp
@@ -6,6 +6,7 @@
 #define CSE_UTILITY_FILESYSTEM_HPP
 
 #include <filesystem>
+
 #include <cse/config.hpp>
 
 
@@ -68,5 +69,6 @@ private:
 };
 
 
-}} // namespace
+} // namespace utility
+} // namespace cse
 #endif // header guard

--- a/src/cpp/cse/utility/uuid.hpp
+++ b/src/cpp/cse/utility/uuid.hpp
@@ -18,5 +18,6 @@ namespace utility
 std::string random_uuid() noexcept;
 
 
-}} // namespace
+} // namespace utility
+} // namespace cse
 #endif // header guard

--- a/src/cpp/cse/utility/zip.hpp
+++ b/src/cpp/cse/utility/zip.hpp
@@ -241,5 +241,7 @@ public:
 };
 
 
-}}} // namespace
+} // namespace zip
+} // namespace utility
+} // namespace cse
 #endif // header guard

--- a/src/cpp/error.cpp
+++ b/src/cpp/error.cpp
@@ -8,15 +8,15 @@ namespace cse
 {
 namespace detail
 {
-    void panic(const char* file, int line, const char* msg) noexcept
-    {
-        std::fprintf(stderr, "%s:%d: Internal error", file, line);
-        if (msg != nullptr) {
-            std::fprintf(stderr, ": %s", msg);
-        }
-        std::fputc('\n', stderr);
-        std::fflush(stderr);
-        std::terminate();
+void panic(const char* file, int line, const char* msg) noexcept
+{
+    std::fprintf(stderr, "%s:%d: Internal error", file, line);
+    if (msg != nullptr) {
+        std::fprintf(stderr, ": %s", msg);
     }
+    std::fputc('\n', stderr);
+    std::fflush(stderr);
+    std::terminate();
 }
-} // namespace
+} // namespace detail
+} // namespace cse

--- a/src/cpp/exception.cpp
+++ b/src/cpp/exception.cpp
@@ -10,33 +10,33 @@ namespace cse
 
 namespace
 {
-    class my_error_category : public std::error_category
+class my_error_category : public std::error_category
+{
+public:
+    const char* name() const noexcept final override
     {
-    public:
-        const char* name() const noexcept final override
-        {
-            return library_short_name;
-        }
+        return library_short_name;
+    }
 
-        std::string message(int ev) const final override
-        {
-            switch (static_cast<errc>(ev)) {
-                case errc::bad_file:
-                    return "Bad file";
-                case errc::unsupported_feature:
-                    return "Unsupported feature";
-                case errc::dl_load_error:
-                    return "Error loading dynamic library";
-                case errc::model_error:
-                    return "Model error";
-                case errc::zip_error:
-                    return "ZIP file error";
-                default:
-                    CSE_PANIC();
-            }
+    std::string message(int ev) const final override
+    {
+        switch (static_cast<errc>(ev)) {
+            case errc::bad_file:
+                return "Bad file";
+            case errc::unsupported_feature:
+                return "Unsupported feature";
+            case errc::dl_load_error:
+                return "Error loading dynamic library";
+            case errc::model_error:
+                return "Model error";
+            case errc::zip_error:
+                return "ZIP file error";
+            default:
+                CSE_PANIC();
         }
-    };
-}
+    }
+};
+} // namespace
 
 
 const std::error_category& error_category() noexcept
@@ -58,4 +58,4 @@ std::error_code make_error_code(errc e) noexcept
 }
 
 
-} // namespace
+} // namespace cse

--- a/src/cpp/fmi_glue.cpp
+++ b/src/cpp/fmi_glue.cpp
@@ -1,6 +1,7 @@
 #include "cse/fmi/glue.hpp"
 
 #include <cassert>
+
 #include "cse/error.hpp"
 #include <cse/exception.hpp>
 
@@ -15,9 +16,9 @@ variable_type to_variable_type(fmi1_base_type_enu_t t)
 {
     switch (t) {
         case fmi1_base_type_real: return variable_type::real;
-        case fmi1_base_type_int:  return variable_type::integer;
+        case fmi1_base_type_int: return variable_type::integer;
         case fmi1_base_type_bool: return variable_type::boolean;
-        case fmi1_base_type_str:  return variable_type::string;
+        case fmi1_base_type_str: return variable_type::string;
         case fmi1_base_type_enum:
             throw cse::error(
                 make_error_code(errc::unsupported_feature),
@@ -32,9 +33,9 @@ variable_type to_variable_type(fmi2_base_type_enu_t t)
 {
     switch (t) {
         case fmi2_base_type_real: return variable_type::real;
-        case fmi2_base_type_int:  return variable_type::integer;
+        case fmi2_base_type_int: return variable_type::integer;
         case fmi2_base_type_bool: return variable_type::boolean;
-        case fmi2_base_type_str:  return variable_type::string;
+        case fmi2_base_type_str: return variable_type::string;
         case fmi2_base_type_enum:
             throw cse::error(
                 make_error_code(errc::unsupported_feature),
@@ -58,7 +59,7 @@ variable_causality to_variable_causality(
             return variable_causality::output;
         case fmi1_causality_enu_internal:
         case fmi1_causality_enu_none:
-             return variable_causality::local;
+            return variable_causality::local;
         default:
             CSE_PANIC();
     }
@@ -68,12 +69,12 @@ variable_causality to_variable_causality(
 variable_causality to_variable_causality(fmi2_causality_enu_t c)
 {
     switch (c) {
-        case fmi2_causality_enu_parameter:              return variable_causality::parameter;
-        case fmi2_causality_enu_calculated_parameter:   return variable_causality::calculated_parameter;
-        case fmi2_causality_enu_input:                  return variable_causality::input;
-        case fmi2_causality_enu_output:                 return variable_causality::output;
+        case fmi2_causality_enu_parameter: return variable_causality::parameter;
+        case fmi2_causality_enu_calculated_parameter: return variable_causality::calculated_parameter;
+        case fmi2_causality_enu_input: return variable_causality::input;
+        case fmi2_causality_enu_output: return variable_causality::output;
         case fmi2_causality_enu_local:
-        case fmi2_causality_enu_independent:            return variable_causality::local;
+        case fmi2_causality_enu_independent: return variable_causality::local;
         default:
             CSE_PANIC();
     }
@@ -83,9 +84,9 @@ variable_causality to_variable_causality(fmi2_causality_enu_t c)
 variable_variability to_variable_variability(fmi1_variability_enu_t v)
 {
     switch (v) {
-        case fmi1_variability_enu_constant:   return variable_variability::constant;
-        case fmi1_variability_enu_parameter:  return variable_variability::fixed;
-        case fmi1_variability_enu_discrete:   return variable_variability::discrete;
+        case fmi1_variability_enu_constant: return variable_variability::constant;
+        case fmi1_variability_enu_parameter: return variable_variability::fixed;
+        case fmi1_variability_enu_discrete: return variable_variability::discrete;
         case fmi1_variability_enu_continuous: return variable_variability::continuous;
         default:
             CSE_PANIC();
@@ -96,11 +97,11 @@ variable_variability to_variable_variability(fmi1_variability_enu_t v)
 variable_variability to_variable_variability(fmi2_variability_enu_t v)
 {
     switch (v) {
-        case fmi2_variability_enu_constant:     return variable_variability::constant;
-        case fmi2_variability_enu_fixed:        return variable_variability::fixed;
-        case fmi2_variability_enu_tunable:      return variable_variability::tunable;
-        case fmi2_variability_enu_discrete:     return variable_variability::discrete;
-        case fmi2_variability_enu_continuous:   return variable_variability::continuous;
+        case fmi2_variability_enu_constant: return variable_variability::constant;
+        case fmi2_variability_enu_fixed: return variable_variability::fixed;
+        case fmi2_variability_enu_tunable: return variable_variability::tunable;
+        case fmi2_variability_enu_discrete: return variable_variability::discrete;
+        case fmi2_variability_enu_continuous: return variable_variability::continuous;
         default:
             CSE_PANIC();
     }
@@ -116,22 +117,21 @@ variable_description to_variable_description(fmi1_import_variable_t* fmiVariable
         fmi1_import_get_variable_vr(fmiVariable),
         to_variable_type(fmi1_import_get_variable_base_type(fmiVariable)),
         to_variable_causality(fmi1_import_get_causality(fmiVariable), fmiVariability),
-        to_variable_variability(fmiVariability)
-    };
+        to_variable_variability(fmiVariability)};
 }
 
 
 variable_description to_variable_description(fmi2_import_variable_t* fmiVariable)
 {
-    assert (fmiVariable != nullptr);
+    assert(fmiVariable != nullptr);
     return {
         fmi2_import_get_variable_name(fmiVariable),
         fmi2_import_get_variable_vr(fmiVariable),
         to_variable_type(fmi2_import_get_variable_base_type(fmiVariable)),
         to_variable_causality(fmi2_import_get_causality(fmiVariable)),
-        to_variable_variability(fmi2_import_get_variability(fmiVariable))
-    };
+        to_variable_variability(fmi2_import_get_variability(fmiVariable))};
 }
 
 
-}} // namespace
+} // namespace fmi
+} // namespace cse

--- a/src/cpp/fmi_v1_fmu.cpp
+++ b/src/cpp/fmi_v1_fmu.cpp
@@ -14,14 +14,14 @@
 #include <gsl/gsl_util>
 
 #include "cse/error.hpp"
-#include <cse/exception.hpp>
 #include "cse/fmi/fmilib.h"
 #include "cse/fmi/glue.hpp"
-#include <cse/fmi/importer.hpp>
 #include "cse/log/logger.hpp"
+#include <cse/exception.hpp>
+#include <cse/fmi/importer.hpp>
 
 #ifdef _WIN32
-#include "cse/fmi/windows.hpp"
+#    include "cse/fmi/windows.hpp"
 #endif
 
 
@@ -56,11 +56,11 @@ fmu::fmu(
             "Not a co-simulation FMU");
     }
 
-    modelDescription_.name          = fmi1_import_get_model_name(handle_);
-    modelDescription_.uuid          = fmi1_import_get_GUID(handle_);
-    modelDescription_.description   = fmi1_import_get_description(handle_);
-    modelDescription_.author        = fmi1_import_get_author(handle_);
-    modelDescription_.version       = fmi1_import_get_model_version(handle_);
+    modelDescription_.name = fmi1_import_get_model_name(handle_);
+    modelDescription_.uuid = fmi1_import_get_GUID(handle_);
+    modelDescription_.description = fmi1_import_get_description(handle_);
+    modelDescription_.author = fmi1_import_get_author(handle_);
+    modelDescription_.version = fmi1_import_get_model_version(handle_);
     const auto varList = fmi1_import_get_variable_list(handle_);
     const auto _ = gsl::finally([&]() {
         fmi1_import_free_variable_list(varList);
@@ -101,15 +101,15 @@ std::shared_ptr<fmi::importer> fmu::importer() const
 
 namespace
 {
-    void prune(std::vector<std::weak_ptr<slave_instance>>& instances)
-    {
-        auto newEnd = std::remove_if(
-            begin(instances),
-            end(instances),
-            [] (const std::weak_ptr<slave_instance>& wp) { return wp.expired(); });
-        instances.erase(newEnd, end(instances));
-    }
+void prune(std::vector<std::weak_ptr<slave_instance>>& instances)
+{
+    auto newEnd = std::remove_if(
+        begin(instances),
+        end(instances),
+        [](const std::weak_ptr<slave_instance>& wp) { return wp.expired(); });
+    instances.erase(newEnd, end(instances));
 }
+} // namespace
 
 
 std::shared_ptr<v1::slave_instance> fmu::instantiate_v1_slave()
@@ -153,101 +153,103 @@ fmi1_import_t* fmu::fmilib_handle() const
 
 namespace
 {
-    void step_finished_placeholder(fmi1_component_t, fmi1_status_t)
-    {
-        BOOST_LOG_SEV(log::logger::get(), log::level::debug)
-            << "FMU instance completed asynchronous step, "
-               "but this feature is currently not supported";
+void step_finished_placeholder(fmi1_component_t, fmi1_status_t)
+{
+    BOOST_LOG_SEV(log::logger::get(), log::level::debug)
+        << "FMU instance completed asynchronous step, "
+           "but this feature is currently not supported";
+}
+
+struct log_record
+{
+    log_record() {}
+    log_record(fmi1_status_t s, const std::string& m)
+        : status{s}
+        , message(m)
+    {}
+    fmi1_status_t status = fmi1_status_ok;
+    std::string message;
+};
+std::unordered_map<std::string, log_record> g_logRecords;
+std::mutex g_logMutex;
+
+void log_message(
+    fmi1_component_t,
+    fmi1_string_t instanceName,
+    fmi1_status_t status,
+    fmi1_string_t category,
+    fmi1_string_t message,
+    ...)
+{
+    std::va_list args;
+    va_start(args, message);
+    const auto msgLength = std::vsnprintf(nullptr, 0, message, args);
+    va_end(args);
+    auto msgBuffer = std::vector<char>(msgLength + 1);
+    va_start(args, message);
+    std::vsnprintf(msgBuffer.data(), msgBuffer.size(), message, args);
+    va_end(args);
+    assert(msgBuffer.back() == '\0');
+
+    std::string statusName = "unknown";
+    log::level logLevel = log::level::error;
+    switch (status) {
+        case fmi1_status_ok:
+            statusName = "ok";
+            logLevel = log::level::info;
+            break;
+        case fmi1_status_warning:
+            statusName = "warning";
+            logLevel = log::level::warning;
+            break;
+        case fmi1_status_discard:
+            // Don't know if this ever happens, but we should at least
+            // print a debug message if it does.
+            statusName = "discard";
+            logLevel = log::level::debug;
+            break;
+        case fmi1_status_error:
+            statusName = "error";
+            logLevel = log::level::error;
+            break;
+        case fmi1_status_fatal:
+            statusName = "fatal";
+            logLevel = log::level::error;
+            break;
+        case fmi1_status_pending:
+            // Don't know if this ever happens, but we should at least
+            // print a debug message if it does.
+            statusName = "pending";
+            logLevel = log::level::debug;
+            break;
     }
+    BOOST_LOG_SEV(log::logger::get(), logLevel)
+        << "[FMI status=" << statusName << ", category=" << category << "] "
+        << msgBuffer.data();
 
-    struct log_record
-    {
-        log_record() { }
-        log_record(fmi1_status_t s, const std::string& m) : status{s}, message(m) { }
-        fmi1_status_t status = fmi1_status_ok;
-        std::string message;
-    };
-    std::unordered_map<std::string, log_record> g_logRecords;
-    std::mutex g_logMutex;
+    g_logMutex.lock();
+    g_logRecords[instanceName] =
+        log_record{status, std::string(msgBuffer.data())};
+    g_logMutex.unlock();
+}
 
-    void log_message(
-        fmi1_component_t,
-        fmi1_string_t instanceName,
-        fmi1_status_t status,
-        fmi1_string_t category,
-        fmi1_string_t message,
-        ...)
-    {
-        std::va_list args;
-        va_start(args, message);
-        const auto msgLength = std::vsnprintf(nullptr, 0, message, args);
-        va_end(args);
-        auto msgBuffer = std::vector<char>(msgLength+1);
-        va_start(args, message);
-        std::vsnprintf(msgBuffer.data(), msgBuffer.size(), message, args);
-        va_end(args);
-        assert(msgBuffer.back() == '\0');
-
-        std::string statusName = "unknown";
-        log::level logLevel = log::level::error;
-        switch (status) {
-            case fmi1_status_ok:
-                statusName = "ok";
-                logLevel = log::level::info;
-                break;
-            case fmi1_status_warning:
-                statusName = "warning";
-                logLevel = log::level::warning;
-                break;
-            case fmi1_status_discard:
-                // Don't know if this ever happens, but we should at least
-                // print a debug message if it does.
-                statusName = "discard";
-                logLevel = log::level::debug;
-                break;
-            case fmi1_status_error:
-                statusName = "error";
-                logLevel = log::level::error;
-                break;
-            case fmi1_status_fatal:
-                statusName = "fatal";
-                logLevel = log::level::error;
-                break;
-            case fmi1_status_pending:
-                // Don't know if this ever happens, but we should at least
-                // print a debug message if it does.
-                statusName = "pending";
-                logLevel = log::level::debug;
-                break;
-        }
-        BOOST_LOG_SEV(log::logger::get(), logLevel)
-            << "[FMI status=" << statusName << ", category=" << category << "] "
-            << msgBuffer.data();
-
-        g_logMutex.lock();
-        g_logRecords[instanceName] =
-            log_record{status, std::string(msgBuffer.data())};
-        g_logMutex.unlock();
-    }
-
-    log_record last_log_record(const std::string& instanceName)
-    {
-        std::lock_guard<std::mutex> lock(g_logMutex);
-        const auto it = g_logRecords.find(instanceName);
-        if (it == g_logRecords.end()) {
-            return log_record{};
-        } else {
-            // Note the use of c_str() here, to force the string to be copied.
-            // The C++ standard now disallows copy-on-write, but some compilers
-            // still use it, which could lead to problems in multithreaded
-            // programs.
-            return log_record{
-                it->second.status,
-                std::string(it->second.message.c_str())
-            };
-        }
+log_record last_log_record(const std::string& instanceName)
+{
+    std::lock_guard<std::mutex> lock(g_logMutex);
+    const auto it = g_logRecords.find(instanceName);
+    if (it == g_logRecords.end()) {
+        return log_record{};
+    } else {
+        // Note the use of c_str() here, to force the string to be copied.
+        // The C++ standard now disallows copy-on-write, but some compilers
+        // still use it, which could lead to problems in multithreaded
+        // programs.
+        return log_record{
+            it->second.status,
+            std::string(it->second.message.c_str())};
     }
 }
+} // namespace
 
 
 slave_instance::slave_instance(std::shared_ptr<v1::fmu> fmu)
@@ -262,9 +264,9 @@ slave_instance::slave_instance(std::shared_ptr<v1::fmu> fmu)
 
     fmi1_callback_functions_t callbacks;
     callbacks.allocateMemory = std::calloc;
-    callbacks.freeMemory     = std::free;
-    callbacks.logger         = log_message;
-    callbacks.stepFinished   = step_finished_placeholder;
+    callbacks.freeMemory = std::free;
+    callbacks.logger = log_message;
+    callbacks.stepFinished = step_finished_placeholder;
 
     if (fmi1_import_create_dllfmu(handle_, callbacks, false) != jm_status_success) {
         const auto msg = fmu->importer()->last_error_message();
@@ -533,4 +535,6 @@ fmi1_import_t* slave_instance::fmilib_handle() const
 }
 
 
-}}} //namespace
+} // namespace v1
+} // namespace fmi
+} // namespace cse

--- a/src/cpp/fmi_windows.cpp
+++ b/src/cpp/fmi_windows.cpp
@@ -1,11 +1,11 @@
 #include "cse/fmi/windows.hpp"
 #ifdef _WIN32
 
-#include <Windows.h>
+#    include <Windows.h>
 
-#include <cassert>
-#include <cstddef>
-#include <mutex>
+#    include <cassert>
+#    include <cstddef>
+#    include <mutex>
 
 
 namespace cse
@@ -15,12 +15,12 @@ namespace fmi
 
 namespace
 {
-    // Maximum size of environment variables
-    constexpr std::size_t max_env_var_size = 32767;
+// Maximum size of environment variables
+constexpr std::size_t max_env_var_size = 32767;
 
-    // Mutex to protect against concurrent access to PATH
-    std::mutex path_env_var_mutex;
-}
+// Mutex to protect against concurrent access to PATH
+std::mutex path_env_var_mutex;
+} // namespace
 
 
 detail::additional_path::additional_path(const std::filesystem::path& p)
@@ -55,8 +55,7 @@ detail::additional_path::~additional_path()
 
     const auto pos = currentPath.find(addedPath_);
     if (pos < std::wstring::npos) {
-        auto newPath = currentPath.substr(0, pos)
-            + currentPath.substr(pos + addedPath_.size());
+        auto newPath = currentPath.substr(0, pos) + currentPath.substr(pos + addedPath_.size());
         if (!SetEnvironmentVariableW(L"PATH", newPath.c_str())) {
             assert(!"Failed to reset PATH environment variable");
         }
@@ -66,14 +65,15 @@ detail::additional_path::~additional_path()
 
 std::filesystem::path fmu_binaries_dir(const std::filesystem::path& baseDir)
 {
-#ifdef _WIN64
+#    ifdef _WIN64
     const auto platformSubdir = L"win64";
-#else
+#    else
     const auto platformSubdir = L"win32";
-#endif // _WIN64
+#    endif // _WIN64
     return baseDir / L"binaries" / platformSubdir;
 }
 
 
-}} // namespace
+} // namespace fmi
+} // namespace cse
 #endif // _WIN32

--- a/src/cpp/hello_world.cpp
+++ b/src/cpp/hello_world.cpp
@@ -16,4 +16,4 @@ std::size_t hello_world(gsl::span<char> buffer) noexcept
 }
 
 
-} // namespace
+} // namespace cse

--- a/src/cpp/libevent.cpp
+++ b/src/cpp/libevent.cpp
@@ -1,9 +1,9 @@
 #include <cse/libevent.hpp>
 
 #ifdef _WIN32
-#   include <winsock2.h>
+#    include <winsock2.h>
 #else
-#   include <sys/time.h>
+#    include <sys/time.h>
 #endif
 
 #include <algorithm>
@@ -52,7 +52,7 @@ public:
 class libevent_event_loop : public event_loop
 {
     // Helpers for automatic management of libevent resources
-    using unique_event_ptr = std::unique_ptr<::event, void(*)(::event*)>;
+    using unique_event_ptr = std::unique_ptr<::event, void (*)(::event*)>;
 
     static unique_event_ptr make_event(
         ::event_base* base,
@@ -69,7 +69,7 @@ class libevent_event_loop : public event_loop
     }
 
     using unique_event_base_ptr =
-        std::unique_ptr<::event_base, void(*)(::event_base*)>;
+        std::unique_ptr<::event_base, void (*)(::event_base*)>;
 
     static unique_event_base_ptr make_event_base()
     {
@@ -105,7 +105,7 @@ class libevent_event_loop : public event_loop
                 eventLoop_.eventBase_.get(),
                 socket_,
                 (persist ? EV_PERSIST : 0) |
-                    ((type & socket_event_type::read ) == socket_event_type::none ? 0 : EV_READ ) |
+                    ((type & socket_event_type::read) == socket_event_type::none ? 0 : EV_READ) |
                     ((type & socket_event_type::write) == socket_event_type::none ? 0 : EV_WRITE),
                 &call_handler,
                 this);
@@ -137,8 +137,8 @@ class libevent_event_loop : public event_loop
             const auto e = reinterpret_cast<socket*>(arg);
             e->handler_->handle_socket_event(
                 e,
-                ((what & EV_READ ) ? socket_event_type::read  : socket_event_type::none) |
-                ((what & EV_WRITE) ? socket_event_type::write : socket_event_type::none));
+                ((what & EV_READ) ? socket_event_type::read : socket_event_type::none) |
+                    ((what & EV_WRITE) ? socket_event_type::write : socket_event_type::none));
         }
 
         libevent_event_loop& eventLoop_;
@@ -177,7 +177,7 @@ class libevent_event_loop : public event_loop
                 this);
 
             timeval tv;
-            tv.tv_sec  = boost::numeric_cast<decltype(tv.tv_sec)> (interval.count() / 1'000'000);
+            tv.tv_sec = boost::numeric_cast<decltype(tv.tv_sec)>(interval.count() / 1'000'000);
             tv.tv_usec = boost::numeric_cast<decltype(tv.tv_usec)>(interval.count() % 1'000'000);
             const auto rc = event_add(ev.get(), &tv);
             if (rc != 0) throw_system_error("libevent: event_add() failed");
@@ -234,7 +234,7 @@ public:
         auto it = std::find_if(
             socketEvents_.begin(),
             socketEvents_.end(),
-            [event] (const socket& item) { return event == &item; });
+            [event](const socket& item) { return event == &item; });
         if (it == socketEvents_.end()) {
             throw std::invalid_argument("Invalid I/O event handle");
         }
@@ -252,7 +252,7 @@ public:
         auto it = std::find_if(
             timerEvents_.begin(),
             timerEvents_.end(),
-            [event] (const timer& item) { return event == &item; });
+            [event](const timer& item) { return event == &item; });
         if (it == timerEvents_.end()) {
             throw std::invalid_argument("Invalid timer event handle");
         }
@@ -304,5 +304,4 @@ std::unique_ptr<event_loop> make_libevent_event_loop()
 }
 
 
-
-} // namespace
+} // namespace cse

--- a/src/cpp/utility_filesystem.cpp
+++ b/src/cpp/utility_filesystem.cpp
@@ -58,4 +58,5 @@ void temp_dir::delete_noexcept() noexcept
 }
 
 
-}} // namespace
+} // namespace utility
+} // namespace cse

--- a/src/cpp/utility_uuid.cpp
+++ b/src/cpp/utility_uuid.cpp
@@ -17,4 +17,5 @@ std::string random_uuid() noexcept
 }
 
 
-}} // namespace
+} // namespace utility
+} // namespace cse

--- a/test/c/hello_world_test.c
+++ b/test/c/hello_world_test.c
@@ -1,5 +1,5 @@
-#include <string.h>
 #include <cse.h>
+#include <string.h>
 
 #define FAILURE 1;
 

--- a/test/c/single_fmu_execution_test.c
+++ b/test/c/single_fmu_execution_test.c
@@ -6,9 +6,10 @@
 
 void print_last_error()
 {
-    fprintf(stderr,
-            "Error code %d: %s\n",
-            cse_last_error_code(), cse_last_error_message());
+    fprintf(
+        stderr,
+        "Error code %d: %s\n",
+        cse_last_error_code(), cse_last_error_message());
 }
 
 

--- a/test/cpp/async_slave_mockup_test.cpp
+++ b/test/cpp/async_slave_mockup_test.cpp
@@ -58,7 +58,7 @@ int main()
     eventLoop->add_timer()->enable(1ms, true, yieldHandler);
 
     // Spin off the event loop in a separate fiber.
-    auto eventLoopFiber = fiber([&] () { eventLoop->loop(); });
+    auto eventLoopFiber = fiber([&]() { eventLoop->loop(); });
 
     try {
         constexpr int numSlaves = 10;
@@ -119,7 +119,7 @@ int main()
             for (const auto& slave : asyncSlaves) {
                 const cse::variable_index realOutIndex = 0;
                 getResults.push_back(
-                    slave->get_variables({&realOutIndex, 1}, { }, { }, { }));
+                    slave->get_variables({&realOutIndex, 1}, {}, {}, {}));
             }
             std::vector<double> values; // To be filled with one value per slave
             for (auto& r : getResults) {
@@ -137,9 +137,9 @@ int main()
                 setResults.push_back(
                     asyncSlaves[i]->set_variables(
                         {&realOutIndex, 1}, {&values[i], 1},
-                        { }, { },
-                        { }, { },
-                        { }, { }));
+                        {}, {},
+                        {}, {},
+                        {}, {}));
             }
             for (auto& r : setResults) {
                 r.get();
@@ -170,10 +170,14 @@ class mock_slave : public cse::slave
 {
 public:
     mock_slave()
-        : realIn_(0.0), realOut_(1.0)
-        , intIn_(0), intOut_(1)
-        , boolIn_(true), boolOut_(false)
-        , stringIn_(), stringOut_()
+        : realIn_(0.0)
+        , realOut_(1.0)
+        , intIn_(0)
+        , intOut_(1)
+        , boolIn_(true)
+        , boolOut_(false)
+        , stringIn_()
+        , stringOut_()
     {
     }
 
@@ -217,8 +221,11 @@ public:
         gsl::span<double> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) values[i] = realOut_;
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                values[i] = realOut_;
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -227,8 +234,11 @@ public:
         gsl::span<int> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) values[i] = intOut_;
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                values[i] = intOut_;
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -237,8 +247,11 @@ public:
         gsl::span<bool> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) values[i] = boolOut_;
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                values[i] = boolOut_;
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -247,8 +260,11 @@ public:
         gsl::span<std::string> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) values[i] = stringOut_;
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                values[i] = stringOut_;
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -257,8 +273,11 @@ public:
         gsl::span<const double> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) realIn_ = values[i];
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                realIn_ = values[i];
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -267,8 +286,11 @@ public:
         gsl::span<const int> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) intIn_ = values[i];
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                intIn_ = values[i];
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -277,8 +299,11 @@ public:
         gsl::span<const bool> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) boolIn_ = values[i];
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                boolIn_ = values[i];
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -287,8 +312,11 @@ public:
         gsl::span<const std::string> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) stringIn_ = values[i];
-            else throw std::out_of_range("bad index");
+            if (variables[i] == 0) {
+                stringIn_ = values[i];
+            } else {
+                throw std::out_of_range("bad index");
+            }
         }
     }
 
@@ -327,7 +355,7 @@ public:
     mock_async_slave(cse::event_loop& eventLoop, cse::slave& slave)
         : eventLoop_(eventLoop)
         , slave_(slave)
-    { }
+    {}
 
     ~mock_async_slave() = default;
 
@@ -340,7 +368,7 @@ public:
     // cse::async_slave function implementations
     boost::fibers::future<cse::model_description> model_description() override
     {
-        return boost::fibers::async([=] () {
+        return boost::fibers::async([=]() {
             loop_wait(eventLoop_, 1ms);
             return slave_.model_description();
         });
@@ -355,7 +383,7 @@ public:
         double relativeTolerance)
         override
     {
-        return boost::fibers::async([=, sn = std::string(slaveName), en = std::string(executionName)] () {
+        return boost::fibers::async([=, sn = std::string(slaveName), en = std::string(executionName)]() {
             loop_wait(eventLoop_, 1ms);
             slave_.setup(sn, en, startTime, stopTime, adaptiveStepSize, relativeTolerance);
         });
@@ -363,7 +391,7 @@ public:
 
     boost::fibers::future<void> start_simulation() override
     {
-        return boost::fibers::async([=] () {
+        return boost::fibers::async([=]() {
             loop_wait(eventLoop_, 1ms);
             slave_.start_simulation();
         });
@@ -371,7 +399,7 @@ public:
 
     boost::fibers::future<void> end_simulation() override
     {
-        return boost::fibers::async([=] () {
+        return boost::fibers::async([=]() {
             loop_wait(eventLoop_, 1ms);
             slave_.end_simulation();
         });
@@ -382,11 +410,13 @@ public:
         cse::time_duration deltaT)
         override
     {
-        return boost::fibers::async([=] () {
+        return boost::fibers::async([=]() {
             loop_wait(eventLoop_, 10ms);
             return slave_.do_step(currentT, deltaT);
         });
     }
+
+    // clang-format off
 
     boost::fibers::future<variable_values> get_variables(
         gsl::span<const cse::variable_index> realVariables,
@@ -407,7 +437,7 @@ public:
                 ivi = to_vector(integerVariables),
                 bvi = to_vector(booleanVariables),
                 svi = to_vector(stringVariables)
-            ] () {
+            ]() {
                 loop_wait(eventLoop_, 1ms);
                 auto rva = gsl::make_span(realBuffer_);
                 auto iva = gsl::make_span(integerBuffer_);
@@ -443,7 +473,7 @@ public:
                 bva = to_vector(booleanValues),
                 svi = to_vector(stringVariables),
                 sva = to_vector(stringValues)
-            ] () {
+            ]() {
                 loop_wait(eventLoop_, 1ms);
                 // NOTE: We don't handle nonfatal_bad_value correctly here.
                 // All functions should get called, and the exceptions should get merged.
@@ -453,6 +483,8 @@ public:
                 slave_.set_string_variables(gsl::make_span(svi), gsl::make_span(sva));
             });
     }
+
+    // clang-format on
 
 private:
     cse::event_loop& eventLoop_;
@@ -480,7 +512,9 @@ class loop_waiter
     : private cse::timer_event_handler
 {
 public:
-    loop_waiter(cse::event_loop& eventLoop) : eventLoop_(eventLoop) { }
+    loop_waiter(cse::event_loop& eventLoop)
+        : eventLoop_(eventLoop)
+    {}
 
     ~loop_waiter() noexcept { assert(event_ == nullptr); }
 

--- a/test/cpp/fmi_v1_fmu_unittest.cpp
+++ b/test/cpp/fmi_v1_fmu_unittest.cpp
@@ -16,85 +16,95 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(fmi::fmi_version)
 
 namespace
 {
-    void run_tests(std::shared_ptr<fmi::fmu> fmu)
-    {
-        BOOST_TEST(fmu->fmi_version() == fmi::fmi_version::v1_0);
-        const auto d = fmu->model_description();
-        BOOST_TEST(d->name == "no.viproma.demo.identity");
-        BOOST_TEST(d->uuid.size() == 36U);
-        BOOST_TEST(d->description ==
-            "Has one input and one output of each type, and outputs are always set equal to inputs");
-        BOOST_TEST(d->author == "Lars Tandle Kyllingstad");
-        BOOST_TEST(d->version == "0.3");
-        BOOST_TEST(std::static_pointer_cast<fmi::v1::fmu>(fmu)->fmilib_handle() != nullptr);
+void run_tests(std::shared_ptr<fmi::fmu> fmu)
+{
+    BOOST_TEST(fmu->fmi_version() == fmi::fmi_version::v1_0);
+    const auto d = fmu->model_description();
+    BOOST_TEST(d->name == "no.viproma.demo.identity");
+    BOOST_TEST(d->uuid.size() == 36U);
+    BOOST_TEST(d->description ==
+        "Has one input and one output of each type, and outputs are always set equal to inputs");
+    BOOST_TEST(d->author == "Lars Tandle Kyllingstad");
+    BOOST_TEST(d->version == "0.3");
+    BOOST_TEST(std::static_pointer_cast<fmi::v1::fmu>(fmu)->fmilib_handle() != nullptr);
 
-        cse::variable_index
-            realIn  = 0, integerIn  = 0, booleanIn  = 0, stringIn = 0,
-            realOut = 0, integerOut = 0, booleanOut = 0, stringOut = 0;
-        for (const auto& v : d->variables) {
-            if      (v.name ==    "realIn" )    realIn  = v.index;
-            else if (v.name == "integerIn" ) integerIn  = v.index;
-            else if (v.name == "booleanIn" ) booleanIn  = v.index;
-            else if (v.name ==  "stringIn" )  stringIn  = v.index;
-            else if (v.name ==    "realOut")    realOut = v.index;
-            else if (v.name == "integerOut") integerOut = v.index;
-            else if (v.name == "booleanOut") booleanOut = v.index;
-            else if (v.name ==  "stringOut")  stringOut = v.index;
-
-            if (v.name == "realIn" ) {
-                BOOST_TEST(v.type == variable_type::real);
-                BOOST_TEST(v.variability == variable_variability::discrete);
-                BOOST_TEST(v.causality == variable_causality::input);
-            } else if (v.name == "stringOut") {
-                BOOST_TEST(v.type == variable_type::string);
-                BOOST_TEST(v.variability == variable_variability::discrete);
-                BOOST_TEST(v.causality == variable_causality::output);
-            }
+    cse::variable_index
+        realIn = 0,
+        integerIn = 0, booleanIn = 0, stringIn = 0,
+        realOut = 0, integerOut = 0, booleanOut = 0, stringOut = 0;
+    for (const auto& v : d->variables) {
+        if (v.name == "realIn") {
+            realIn = v.index;
+        } else if (v.name == "integerIn") {
+            integerIn = v.index;
+        } else if (v.name == "booleanIn") {
+            booleanIn = v.index;
+        } else if (v.name == "stringIn") {
+            stringIn = v.index;
+        } else if (v.name == "realOut") {
+            realOut = v.index;
+        } else if (v.name == "integerOut") {
+            integerOut = v.index;
+        } else if (v.name == "booleanOut") {
+            booleanOut = v.index;
+        } else if (v.name == "stringOut") {
+            stringOut = v.index;
         }
 
-        const double tMax = 1.0;
-        const double dt = 0.1;
-        double realVal = 0.0;
-        int integerVal = 0;
-        bool booleanVal = false;
-        std::string stringVal;
-
-        auto instance = fmu->instantiate_slave();
-        instance->setup("testSlave", "testExecution", 0.0, tMax, false, 0.0);
-        instance->start_simulation();
-
-        for (double t = 0; t < tMax; t += dt) {
-            double getRealVal = -1.0;
-            int getIntegerVal = -1;
-            bool getBooleanVal = true;
-            std::string getStringVal = "unexpected value";
-
-            instance->get_real_variables   (gsl::make_span(&realOut,    1), gsl::make_span(&getRealVal, 1));
-            instance->get_integer_variables(gsl::make_span(&integerOut, 1), gsl::make_span(&getIntegerVal, 1));
-            instance->get_boolean_variables(gsl::make_span(&booleanOut, 1), gsl::make_span(&getBooleanVal, 1));
-            instance->get_string_variables (gsl::make_span(&stringOut,  1), gsl::make_span(&getStringVal, 1));
-
-            BOOST_TEST(   getRealVal == realVal);
-            BOOST_TEST(getIntegerVal == integerVal);
-            BOOST_TEST(getBooleanVal == booleanVal);
-            BOOST_TEST( getStringVal == stringVal);
-
-            realVal += 1.0;
-            integerVal += 1;
-            booleanVal = !booleanVal;
-            stringVal += 'a';
-
-            instance->set_real_variables   (gsl::make_span(&realIn,    1), gsl::make_span(&realVal,    1));
-            instance->set_integer_variables(gsl::make_span(&integerIn, 1), gsl::make_span(&integerVal, 1));
-            instance->set_boolean_variables(gsl::make_span(&booleanIn, 1), gsl::make_span(&booleanVal, 1));
-            instance->set_string_variables (gsl::make_span(&stringIn,  1), gsl::make_span(&stringVal , 1));
-
-            BOOST_TEST(instance->do_step(t, dt));
+        if (v.name == "realIn") {
+            BOOST_TEST(v.type == variable_type::real);
+            BOOST_TEST(v.variability == variable_variability::discrete);
+            BOOST_TEST(v.causality == variable_causality::input);
+        } else if (v.name == "stringOut") {
+            BOOST_TEST(v.type == variable_type::string);
+            BOOST_TEST(v.variability == variable_variability::discrete);
+            BOOST_TEST(v.causality == variable_causality::output);
         }
-
-        instance->end_simulation();
     }
+
+    const double tMax = 1.0;
+    const double dt = 0.1;
+    double realVal = 0.0;
+    int integerVal = 0;
+    bool booleanVal = false;
+    std::string stringVal;
+
+    auto instance = fmu->instantiate_slave();
+    instance->setup("testSlave", "testExecution", 0.0, tMax, false, 0.0);
+    instance->start_simulation();
+
+    for (double t = 0; t < tMax; t += dt) {
+        double getRealVal = -1.0;
+        int getIntegerVal = -1;
+        bool getBooleanVal = true;
+        std::string getStringVal = "unexpected value";
+
+        instance->get_real_variables(gsl::make_span(&realOut, 1), gsl::make_span(&getRealVal, 1));
+        instance->get_integer_variables(gsl::make_span(&integerOut, 1), gsl::make_span(&getIntegerVal, 1));
+        instance->get_boolean_variables(gsl::make_span(&booleanOut, 1), gsl::make_span(&getBooleanVal, 1));
+        instance->get_string_variables(gsl::make_span(&stringOut, 1), gsl::make_span(&getStringVal, 1));
+
+        BOOST_TEST(getRealVal == realVal);
+        BOOST_TEST(getIntegerVal == integerVal);
+        BOOST_TEST(getBooleanVal == booleanVal);
+        BOOST_TEST(getStringVal == stringVal);
+
+        realVal += 1.0;
+        integerVal += 1;
+        booleanVal = !booleanVal;
+        stringVal += 'a';
+
+        instance->set_real_variables(gsl::make_span(&realIn, 1), gsl::make_span(&realVal, 1));
+        instance->set_integer_variables(gsl::make_span(&integerIn, 1), gsl::make_span(&integerVal, 1));
+        instance->set_boolean_variables(gsl::make_span(&booleanIn, 1), gsl::make_span(&booleanVal, 1));
+        instance->set_string_variables(gsl::make_span(&stringIn, 1), gsl::make_span(&stringVal, 1));
+
+        BOOST_TEST(instance->do_step(t, dt));
+    }
+
+    instance->end_simulation();
 }
+} // namespace
 
 
 BOOST_AUTO_TEST_CASE(v1_fmu)
@@ -114,7 +124,7 @@ BOOST_AUTO_TEST_CASE(v1_fmu_unpacked)
     BOOST_TEST_REQUIRE(!!testDataDir);
     utility::temp_dir unpackDir;
     utility::zip::archive(
-            std::filesystem::path(testDataDir) / "fmi1" / "identity.fmu")
+        std::filesystem::path(testDataDir) / "fmi1" / "identity.fmu")
         .extract_all(unpackDir.path());
 
     auto importer = fmi::importer::create();

--- a/test/cpp/fmi_v2_fmu_unittest.cpp
+++ b/test/cpp/fmi_v2_fmu_unittest.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(v2_fmu)
     auto importer = fmi::importer::create();
     const std::string modelName = "WaterTank_Control";
     auto fmu = importer->import(
-        std::filesystem::path(testDataDir) / "fmi2" / (modelName+".fmu"));
+        std::filesystem::path(testDataDir) / "fmi2" / (modelName + ".fmu"));
 
     BOOST_TEST(fmu->fmi_version() == fmi::fmi_version::v2_0);
     const auto d = fmu->model_description();

--- a/test/cpp/hello_world_test.cpp
+++ b/test/cpp/hello_world_test.cpp
@@ -1,5 +1,5 @@
-#include <cstring>
 #include <cse/hello_world.hpp>
+#include <cstring>
 
 constexpr int failure = 1;
 

--- a/test/cpp/libevent_unittest.cpp
+++ b/test/cpp/libevent_unittest.cpp
@@ -11,43 +11,43 @@ using namespace cse;
 
 namespace
 {
-    class timer_event_function : public timer_event_handler
+class timer_event_function : public timer_event_handler
+{
+public:
+    timer_event_function(
+        event_loop& eventLoop,
+        std::chrono::microseconds interval,
+        bool persist,
+        std::function<void(timer_event*)> handler)
+        : handler_(handler)
     {
-    public:
-        timer_event_function(
-            event_loop& eventLoop,
-            std::chrono::microseconds interval,
-            bool persist,
-            std::function<void(timer_event*)> handler)
-            : handler_(handler)
-        {
-            eventLoop.add_timer()->enable(interval, persist, *this);
-        }
-
-        ~timer_event_function() = default;
-
-        timer_event_function(const timer_event_function&) = delete;
-        timer_event_function& operator=(const timer_event_function&) = delete;
-        timer_event_function(timer_event_function&&) = delete;
-        timer_event_function& operator=(timer_event_function&&) = delete;
-
-        void handle_timer_event(timer_event* event) override
-        {
-            handler_(event);
-        }
-
-    private:
-        std::function<void(timer_event*)> handler_;
-    };
-
-    template<typename T, typename D>
-    bool approx_equal_duration(T t1, T t2, D dur)
-    {
-        constexpr auto epsilon = 10ms;
-        const auto diff = t2 - t1 - dur;
-        return -epsilon <= diff && diff <= epsilon;
+        eventLoop.add_timer()->enable(interval, persist, *this);
     }
+
+    ~timer_event_function() = default;
+
+    timer_event_function(const timer_event_function&) = delete;
+    timer_event_function& operator=(const timer_event_function&) = delete;
+    timer_event_function(timer_event_function&&) = delete;
+    timer_event_function& operator=(timer_event_function&&) = delete;
+
+    void handle_timer_event(timer_event* event) override
+    {
+        handler_(event);
+    }
+
+private:
+    std::function<void(timer_event*)> handler_;
+};
+
+template<typename T, typename D>
+bool approx_equal_duration(T t1, T t2, D dur)
+{
+    constexpr auto epsilon = 10ms;
+    const auto diff = t2 - t1 - dur;
+    return -epsilon <= diff && diff <= epsilon;
 }
+} // namespace
 
 
 BOOST_AUTO_TEST_CASE(libevent_timers)
@@ -66,17 +66,17 @@ BOOST_AUTO_TEST_CASE(libevent_timers)
         *eventLoop,
         0us,
         false,
-        [&] (timer_event*) { immediateTriggered = std::chrono::steady_clock::now(); });
+        [&](timer_event*) { immediateTriggered = std::chrono::steady_clock::now(); });
     timer_event_function delayed(
         *eventLoop,
         delayedDuration,
         false,
-        [&] (timer_event*) { delayedTriggered = std::chrono::steady_clock::now(); });
+        [&](timer_event*) { delayedTriggered = std::chrono::steady_clock::now(); });
     timer_event_function recurring(
         *eventLoop,
         recurringDuration,
         true,
-        [&] (timer_event* e) {
+        [&](timer_event* e) {
             recurringTriggered.push_back(std::chrono::steady_clock::now());
             if (recurringTriggered.size() == 3) e->event_loop().stop_soon();
         });
@@ -88,6 +88,6 @@ BOOST_AUTO_TEST_CASE(libevent_timers)
     BOOST_TEST(approx_equal_duration(startTime, delayedTriggered, delayedDuration));
     BOOST_TEST(recurringTriggered.size() == 3);
     for (std::size_t i = 0; i < recurringTriggered.size(); ++i) {
-        BOOST_TEST(approx_equal_duration(startTime, recurringTriggered[i], long(i+1)*recurringDuration));
+        BOOST_TEST(approx_equal_duration(startTime, recurringTriggered[i], long(i + 1) * recurringDuration));
     }
 }

--- a/test/cpp/utility_zip_unittest.cpp
+++ b/test/cpp/utility_zip_unittest.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(zip_archive)
         BOOST_TEST(fs::is_regular_file(txtExtracted));
         BOOST_TEST(fs::file_size(binExtracted) == binSize);
         BOOST_TEST(fs::file_size(txtExtracted) == txtSize);
-        BOOST_CHECK_THROW(archive.extract_file_to(binIndex, tempDir.path()/"nonexistent"), std::system_error);
+        BOOST_CHECK_THROW(archive.extract_file_to(binIndex, tempDir.path() / "nonexistent"), std::system_error);
     }
 
     // Extract individual entries
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(zip_archive)
         BOOST_TEST(fs::file_size(binExtracted) == binSize);
         BOOST_TEST(fs::file_size(txtExtracted) == txtSize);
         BOOST_CHECK_THROW(archive.extract_file_to(invIndex, tempDir.path()), uz::error);
-        BOOST_CHECK_THROW(archive.extract_file_to(binIndex, tempDir.path()/"nonexistent"), std::system_error);
+        BOOST_CHECK_THROW(archive.extract_file_to(binIndex, tempDir.path() / "nonexistent"), std::system_error);
     }
 
     archive.discard();


### PR DESCRIPTION
This is the result of applying clang-format to all code, with a few manual interventions here and there. I had to use `// clang-format off` in one place, but that was a special case which I could not find any other way to format nicely.