### PR TITLE
Enable changing the output log level

### DIFF
--- a/include/cse/log.hpp
+++ b/include/cse/log.hpp
@@ -5,11 +5,13 @@
 #ifndef CSE_LOG_HPP
 #define CSE_LOG_HPP
 
+#include <ostream>
+
+
 namespace cse
 {
 namespace log
 {
-
 
 /// Severity levels for logged messages.
 enum class level
@@ -21,6 +23,32 @@ enum class level
     error,
     fatal
 };
+
+
+/// Returns a textual representation of `lvl`.
+constexpr const char* to_text(level lvl) noexcept
+{
+    switch (lvl) {
+        case level::trace: return "trace";
+        case level::debug: return "debug";
+        case level::info: return "info";
+        case level::warning: return "warning";
+        case level::error: return "error";
+        case level::fatal: return "fatal";
+        default: return nullptr;
+    }
+}
+
+
+/// Writes a textual representation of `lvl` to `stream`.
+inline std::ostream& operator<<(std::ostream& stream, level lvl)
+{
+    return stream << to_text(lvl);
+}
+
+
+/// Sets the global output log level.
+void set_global_output_level(level lvl);
 
 
 } // namespace log

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -38,6 +38,7 @@ set(sources
     "fmi_glue.cpp"
     "fmi_windows.cpp"
     "libevent.cpp"
+    "log.cpp"
     "utility_filesystem.cpp"
     "utility_uuid.cpp"
     "utility_zip.cpp"

--- a/src/cpp/cse/log/logger.hpp
+++ b/src/cpp/cse/log/logger.hpp
@@ -5,10 +5,12 @@
 #ifndef CSE_LOG_LOGGER_HPP
 #define CSE_LOG_LOGGER_HPP
 
+#include <boost/log/expressions/keyword.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/sources/severity_feature.hpp>
 #include <boost/log/sources/severity_logger.hpp>
+
 #include <cse/log.hpp>
 
 
@@ -17,10 +19,12 @@ namespace cse
 namespace log
 {
 
-
 BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
     logger,
     boost::log::sources::severity_logger_mt<level>)
+
+BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", level)
+
 }
 } // namespace cse
 #endif // header guard

--- a/src/cpp/log.cpp
+++ b/src/cpp/log.cpp
@@ -1,0 +1,20 @@
+#include <cse/log.hpp>
+
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
+
+#include "cse/log/logger.hpp"
+
+
+namespace cse
+{
+namespace log
+{
+
+void set_global_output_level(level lvl)
+{
+    boost::log::core::get()->set_filter(severity >= lvl);
+}
+
+} // namespace log
+}


### PR DESCRIPTION
@eidekrist, this should enable you to change the output log level to reduce the amount of output printed to screen, as requested. It does not address issue #48, but that one turns out to be an issue with *how* the messages are printed, and not *whether* they are printed. (I.e., a `warning` message will be treated internally as such, but it will still print "info"...) I'll get to that as soon as I can.