### PR TITLE
Set up custom logging sink

### DIFF
--- a/src/cpp/cse/log/logger.hpp
+++ b/src/cpp/cse/log/logger.hpp
@@ -5,11 +5,10 @@
 #ifndef CSE_LOG_LOGGER_HPP
 #define CSE_LOG_LOGGER_HPP
 
-#include <boost/log/expressions/keyword.hpp>
-#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/severity_logger.hpp>
+// These are just to introduce some convenient macros like BOOST_LOG_SEV:
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/sources/severity_feature.hpp>
-#include <boost/log/sources/severity_logger.hpp>
 
 #include <cse/log.hpp>
 
@@ -19,11 +18,10 @@ namespace cse
 namespace log
 {
 
-BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(
-    logger,
-    boost::log::sources::severity_logger_mt<level>)
+using logger_type = boost::log::sources::severity_logger_mt<level>;
 
-BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", level)
+/// Returns the global logger.
+logger_type& logger();
 
 }
 } // namespace cse

--- a/src/cpp/fmi_importer.cpp
+++ b/src/cpp/fmi_importer.cpp
@@ -73,8 +73,8 @@ void logger_callback(
 {
     const auto myLevel = convert_log_level(logLevel);
     // Errors are dealt with with exceptions
-    BOOST_LOG_SEV(log::logger::get(), myLevel)
-        << "FMI Library: " << module << "] " << message;
+    BOOST_LOG_SEV(log::logger(), myLevel)
+        << "[FMI Library: " << module << "] " << message;
 }
 
 std::unique_ptr<jm_callbacks> make_callbacks()

--- a/src/cpp/fmi_v1_fmu.cpp
+++ b/src/cpp/fmi_v1_fmu.cpp
@@ -155,7 +155,7 @@ namespace
 {
 void step_finished_placeholder(fmi1_component_t, fmi1_status_t)
 {
-    BOOST_LOG_SEV(log::logger::get(), log::level::debug)
+    BOOST_LOG_SEV(log::logger(), log::level::debug)
         << "FMU instance completed asynchronous step, "
            "but this feature is currently not supported";
 }
@@ -223,7 +223,7 @@ void log_message(
             logLevel = log::level::debug;
             break;
     }
-    BOOST_LOG_SEV(log::logger::get(), logLevel)
+    BOOST_LOG_SEV(log::logger(), logLevel)
         << "[FMI status=" << statusName << ", category=" << category << "] "
         << msgBuffer.data();
 

--- a/src/cpp/fmi_v2_fmu.cpp
+++ b/src/cpp/fmi_v2_fmu.cpp
@@ -155,7 +155,7 @@ namespace
 {
 void step_finished_placeholder(fmi2_component_environment_t, fmi2_status_t)
 {
-    BOOST_LOG_SEV(log::logger::get(), log::level::debug)
+    BOOST_LOG_SEV(log::logger(), log::level::debug)
         << "FMU instance completed asynchronous step, "
            "but this feature is currently not supported";
 }
@@ -223,7 +223,7 @@ void log_message(
             logLevel = log::level::debug;
             break;
     }
-    BOOST_LOG_SEV(log::logger::get(), logLevel)
+    BOOST_LOG_SEV(log::logger(), logLevel)
         << "[FMI status=" << statusName << ", category=" << category << "] "
         << msgBuffer.data();
 

--- a/src/cpp/log.cpp
+++ b/src/cpp/log.cpp
@@ -1,7 +1,13 @@
 #include <cse/log.hpp>
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/log/attributes.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_ostream_backend.hpp>
+#include <boost/log/support/date_time.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
 
 #include "cse/log/logger.hpp"
 
@@ -10,11 +16,51 @@ namespace cse
 {
 namespace log
 {
+namespace
+{
+// A keyword for referring to severity level in filters, formatters
+// and such.
+BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", level)
+
+
+// Initialises the logging systems and returns a global
+// logger source.
+logger_type setup_logger()
+{
+    using namespace boost::log;
+    add_common_attributes();
+
+    // Set up a sink that writes to the console
+    using text_sink = sinks::synchronous_sink<sinks::text_ostream_backend>;
+    auto sink = boost::make_shared<text_sink>();
+    sink->locked_backend()->add_stream(
+        boost::shared_ptr<std::ostream>(&std::clog, [](void*) { /*delete nothing*/ }));
+
+    sink->set_formatter(
+        expressions::stream
+        << expressions::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S.%f")
+        << " [" << std::left << std::setw(7) << severity << "] "
+        << expressions::smessage);
+    core::get()->add_sink(sink);
+
+    // Create and return logger
+    return logger_type(level::info);
+}
+} // namespace
+
 
 void set_global_output_level(level lvl)
 {
     boost::log::core::get()->set_filter(severity >= lvl);
 }
 
-} // namespace log
+
+logger_type& logger()
+{
+    static logger_type logger_ = setup_logger();
+    return logger_;
 }
+
+
+} // namespace log
+} // namespace cse


### PR DESCRIPTION
The default logging sink in Boost.Log apparently does not support custom log level definitions, which was the cause of issue #48. This PR sets up a custom sink that writes to the standard log stream (which is really just the standard error stream) with custom message formatting, fixing that issue.

The nice part is that this prepares the way for other custom sinks in the future, like log files, network logging or whatever.