### PR TITLE
Only search for Boost header-only libraries when using Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,14 +77,20 @@ set(CSECORE_EXPORT_TARGET "${PROJECT_NAME}-targets")
 # Dependencies
 # ==============================================================================
 
+set(boostHeaderLibs test uuid)
+set(boostBinaryLibs context fiber log system thread)
+
 if(CSECORE_USING_CONAN)
     include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     conan_basic_setup(NO_OUTPUT_DIRS)
+    set(boostComponents ${boostHeaderLibs} ${boostBinaryLibs})
+else()
+    set(boostComponents ${boostBinaryLibs})
 endif()
 
 find_package(Threads REQUIRED) # OS thread library
 find_package(GSL REQUIRED)
-find_package(Boost REQUIRED COMPONENTS context fiber log system test thread uuid)
+find_package(Boost REQUIRED COMPONENTS ${boostComponents})
 find_package(FMILibrary REQUIRED)
 find_package(LIBZIP REQUIRED)
 find_package(Libevent2 REQUIRED)


### PR DESCRIPTION
This addresses an issue reported by @jornsv on Slack.

When Conan is used for dependency management, [a custom FindBoost script](https://github.com/bincrafters/conan-cmake_findboost_modular) is used to locate Boost headers and libraries. It is mostly compatible with the one bundled with CMake, with the exception that one must specify header-only components in addition to binary components in the `find_package` command. (The reason is that with Bincrafters' Boost packages for Conan, the different sub-libraries get installed into separate directories.)

This PR ensures that we only search for header-only libraries when `CSECORE_USING_CONAN` is `TRUE`.