### PR TITLE
Using virtualrunenv for Linux builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,14 +129,14 @@ pipeline {
                         stage ('Test Debug') {
                             steps {
                                 dir('debug-build') {
-                                    sh 'ctest -C Debug -T Test --no-compress-output --test-output-size-passed 307200 || true'
+                                    sh '. ./activate_run.sh && ctest -C Debug -T Test --no-compress-output --test-output-size-passed 307200 || true'
                                 }
                             }
                         }
                         stage ('Test Release') {
                             steps {
                                 dir('release-build') {
-                                    sh 'ctest -C Release -T Test --no-compress-output --test-output-size-passed 307200 || true'
+                                    sh '. ./activate_run.sh && ctest -C Release -T Test --no-compress-output --test-output-size-passed 307200 || true'
                                 }
                             }
                         }

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conans import ConanFile, CMake, tools
 
 class CSECoreConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "virtualrunenv"
     requires = (
         "boost_algorithm/1.66.0@bincrafters/stable",
         "boost_fiber/1.66.0@bincrafters/stable",


### PR DESCRIPTION
Using virtualrunenv to get dependencies on LD_LIBRARY_PATH for Linux builds.