### PR TITLE
Hide some Boost-related platform-specific quirks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,17 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_options("/W4" "/WX")
     add_compile_options("/wd4996")
+    if(CSECORE_USING_CONAN)
+        # C4251: 'identifier' : class 'type' needs to have dll-interface to be
+        #        used by clients of class 'type2'
+        #
+        # This could be a problem if a dependent DLL is compiled against a
+        # different version or variant of the C++ runtime than the one we
+        # use.  An example would be if Boost was built in release mode and
+        # we are compiling in release mode. However, when we use Conan, this
+        # should not be a problem, so we disable the warning.
+        add_compile_options("/wd4251")
+    endif()
     add_definitions("-D_SCL_SECURE_NO_WARNINGS")
 endif()
 
@@ -77,15 +88,13 @@ set(CSECORE_EXPORT_TARGET "${PROJECT_NAME}-targets")
 # Dependencies
 # ==============================================================================
 
-set(boostHeaderLibs test uuid)
-set(boostBinaryLibs context fiber filesystem log system thread)
-
+set(boostComponents context date_time fiber filesystem log system thread)
 if(CSECORE_USING_CONAN)
     include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
     conan_basic_setup(NO_OUTPUT_DIRS)
-    set(boostComponents ${boostHeaderLibs} ${boostBinaryLibs})
+    list(APPEND boostComponents test uuid)
 else()
-    set(boostComponents ${boostBinaryLibs})
+    list(APPEND boostComponents unit_test_framework)
 endif()
 
 find_package(Threads REQUIRED) # OS thread library

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,6 @@ class CSECoreConan(ConanFile):
         )
     default_options = (
         "boost_*:shared=True",
-        "boost_test:shared=False",
         "libevent:with_openssl=False",
         "libzip:shared=True"
         )

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -67,6 +67,7 @@ endforeach()
 set(allSources ${publicHeadersFull} ${privateHeadersFull} ${sources})
 
 add_library(csecorecpp ${allSources})
+target_compile_definitions(csecorecpp PUBLIC "BOOST_ALL_DYN_LINK=1" "BOOST_ALL_NO_LIB=1")
 target_compile_features(csecorecpp PUBLIC "cxx_std_17")
 target_include_directories(csecorecpp
     PUBLIC
@@ -81,6 +82,7 @@ target_link_libraries(csecorecpp
         libevent2::core
         Boost::boost
         Boost::context
+        Boost::date_time
         Boost::fiber
         Boost::filesystem
         Boost::log

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -21,12 +21,18 @@ foreach(test IN LISTS tests)
         DEPENDENCIES csecorecpp
     )
 endforeach()
+
+if(CSECORE_USING_CONAN)
+    set(unittestDeps "Boost::test")
+else()
+    set(unittestDeps "Boost::unit_test_framework")
+endif()
 foreach(test IN LISTS unittests)
     add_test_executable(
         "cpp_${test}"
         FOLDER "C++ unit tests"
         SOURCES "${test}.cpp"
-        DEPENDENCIES csecorecpp Boost::test
+        DEPENDENCIES csecorecpp ${unittestDeps}
         DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../data"
     )
     target_include_directories("cpp_${test}" PRIVATE "$<TARGET_PROPERTY:csecorecpp,SOURCE_DIR>")


### PR DESCRIPTION
To the extent possible, we should try to ensure that the build process is the same regardless of whether one uses Windows or Linux, Conan or other package managers.  Here I've made the following changes:

  - For Boost.Test, use target `Boost::test` with Conan and `Boost::unit_test_framework` otherwise.
  - Use dynamic Boost libraries, regardless of platform.
  - Disable the (Windows-specific) auto-linking feature.
  - Disable [MSVC warning C4251](https://docs.microsoft.com/en-gb/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=vs-2017) when using Conan, as I expect Conan to handle the problem it warns about.