### PR TITLE
Relax libevent timer test a bit

### DIFF
--- a/test/cpp/libevent_unittest.cpp
+++ b/test/cpp/libevent_unittest.cpp
@@ -43,7 +43,7 @@ private:
 template<typename T, typename D>
 bool approx_equal_duration(T t1, T t2, D dur)
 {
-    constexpr auto epsilon = 10ms;
+    constexpr auto epsilon = 20ms;
     const auto diff = t2 - t1 - dur;
     return -epsilon <= diff && diff <= epsilon;
 }


### PR DESCRIPTION
Apparently, a tolerance of 10ms is a bit too strict for the build node, so let's try doubling it.  This hopefully fixes issue #74.