### PR TITLE
Rename expose_xxx() functions to make_yyy()

### DIFF
--- a/include/cse/algorithm.hpp
+++ b/include/cse/algorithm.hpp
@@ -38,7 +38,7 @@ class simulator : public observable
 {
 public:
     /**
-     *  Exposes an input variable for assignment with `set_xxx()`.
+     *  Exposes a variable for assignment with `set_xxx()`.
      *
      *  The purpose is fundamentally to select which variables get transferred
      *  to remote simulators at each step, so that each individual `set_xxx()`
@@ -47,33 +47,33 @@ public:
      *  Calling this function more than once for the same variable has no
      *  effect.
      */
-    virtual void expose_input(variable_type type, variable_index index) = 0;
+    virtual void expose_for_setting(variable_type type, variable_index index) = 0;
 
     /**
      *  Sets the value of a real variable.
      *
-     *  The variable must previously have been exposed with `expose_input()`.
+     *  The variable must previously have been exposed with `expose_for_setting()`.
      */
     virtual void set_real(variable_index index, double value) = 0;
 
     /**
      *  Sets the value of an integer variable.
      *
-     *  The variable must previously have been exposed with `expose_input()`.
+     *  The variable must previously have been exposed with `expose_for_setting()`.
      */
     virtual void set_integer(variable_index index, int value) = 0;
 
     /**
      *  Sets the value of a boolean variable.
      *
-     *  The variable must previously have been exposed with `expose_input()`.
+     *  The variable must previously have been exposed with `expose_for_setting()`.
      */
     virtual void set_boolean(variable_index index, bool value) = 0;
 
     /**
      *  Sets the value of a string variable.
      *
-     *  The variable must previously have been exposed with `expose_input()`.
+     *  The variable must previously have been exposed with `expose_for_setting()`.
      */
     virtual void set_string(variable_index index, std::string_view value) = 0;
 

--- a/include/cse/observer.hpp
+++ b/include/cse/observer.hpp
@@ -29,39 +29,39 @@ public:
     virtual cse::model_description model_description() const = 0;
 
     /**
-     *  Exposes an output variable for retrieval with `get_xxx()`.
+     *  Exposes a variable for retrieval with `get_xxx()`.
      *
      *  The purpose is fundamentally to select which variables get transferred
      *  from remote simulators at each step, so that each individual `get_xxx()`
      *  function call doesn't trigger a separate RPC operation.
      */
-    virtual void expose_output(variable_type, variable_index) = 0;
+    virtual void expose_for_getting(variable_type, variable_index) = 0;
 
     /**
      *  Returns the value of a real variable.
      *
-     *  The variable must previously have been exposed with `expose_output()`.
+     *  The variable must previously have been exposed with `expose_for_getting()`.
      */
     virtual double get_real(variable_index) const = 0;
 
     /**
      *  Returns the value of an integer variable.
      *
-     *  The variable must previously have been exposed with `expose_output()`.
+     *  The variable must previously have been exposed with `expose_for_getting()`.
      */
     virtual int get_integer(variable_index) const = 0;
 
     /**
      *  Returns the value of a boolean variable.
      *
-     *  The variable must previously have been exposed with `expose_output()`.
+     *  The variable must previously have been exposed with `expose_for_getting()`.
      */
     virtual bool get_boolean(variable_index) const = 0;
 
     /**
      *  Returns the value of a string variable.
      *
-     *  The variable must previously have been exposed with `expose_output()`.
+     *  The variable must previously have been exposed with `expose_for_getting()`.
      *
      *  The returned `std::string_view` is only guaranteed to remain valid
      *  until the next call of this or any other of the object's methods.

--- a/src/cpp/algorithm.cpp
+++ b/src/cpp/algorithm.cpp
@@ -68,8 +68,8 @@ public:
         bool inputAlreadyConnected)
     {
         if (inputAlreadyConnected) disconnect_variable(input);
-        simulators_[output.simulator]->expose_output(output.type, output.index);
-        simulators_[input.simulator]->expose_input(input.type, input.index);
+        simulators_[output.simulator]->expose_for_getting(output.type, output.index);
+        simulators_[input.simulator]->expose_for_setting(input.type, input.index);
         connections_.push_back({output, input});
     }
 

--- a/src/cpp/cse/slave_simulator.hpp
+++ b/src/cpp/cse/slave_simulator.hpp
@@ -33,14 +33,14 @@ public:
     std::string name() const override;
     cse::model_description model_description() const override;
 
-    void expose_output(variable_type type, variable_index index) override;
+    void expose_for_getting(variable_type type, variable_index index) override;
     double get_real(variable_index index) const override;
     int get_integer(variable_index index) const override;
     bool get_boolean(variable_index index) const override;
     std::string_view get_string(variable_index index) const override;
 
     // `simulator` methods
-    void expose_input(variable_type type, variable_index index) override;
+    void expose_for_setting(variable_type type, variable_index index) override;
     void set_real(variable_index index, double value) override;
     void set_integer(variable_index index, int value) override;
     void set_boolean(variable_index index, bool value) override;

--- a/src/cpp/membuffer_observer.cpp
+++ b/src/cpp/membuffer_observer.cpp
@@ -70,7 +70,7 @@ public:
         : observable_(observable)
     {
         for (const auto& vd : observable->model_description().variables) {
-            observable->expose_output(vd.type, vd.index);
+            observable->expose_for_getting(vd.type, vd.index);
             if (vd.type == cse::variable_type::real) {
                 realIndexes_.push_back(vd.index);
             }

--- a/src/cpp/slave_simulator.cpp
+++ b/src/cpp/slave_simulator.cpp
@@ -88,80 +88,80 @@ public:
     }
 
 
-    void expose_output(variable_type type, variable_index index)
+    void expose_for_getting(variable_type type, variable_index index)
     {
         switch (type) {
             case variable_type::real:
-                realOutputs_.expose(index);
+                realGetCache_.expose(index);
                 break;
             case variable_type::integer:
-                integerOutputs_.expose(index);
+                integerGetCache_.expose(index);
                 break;
             case variable_type::boolean:
-                booleanOutputs_.expose(index);
+                booleanGetCache_.expose(index);
                 break;
             case variable_type::string:
-                stringOutputs_.expose(index);
+                stringGetCache_.expose(index);
                 break;
         }
     }
 
     double get_real(variable_index index) const
     {
-        return realOutputs_.get(index);
+        return realGetCache_.get(index);
     }
 
     int get_integer(variable_index index) const
     {
-        return integerOutputs_.get(index);
+        return integerGetCache_.get(index);
     }
 
     bool get_boolean(variable_index index) const
     {
-        return booleanOutputs_.get(index);
+        return booleanGetCache_.get(index);
     }
 
     std::string_view get_string(variable_index index) const
     {
-        return stringOutputs_.get(index);
+        return stringGetCache_.get(index);
     }
 
-    void expose_input(variable_type type, variable_index index)
+    void expose_for_setting(variable_type type, variable_index index)
     {
         switch (type) {
             case variable_type::real:
-                realInputs_.expose(index);
+                realSetCache_.expose(index);
                 break;
             case variable_type::integer:
-                integerInputs_.expose(index);
+                integerSetCache_.expose(index);
                 break;
             case variable_type::boolean:
-                booleanInputs_.expose(index);
+                booleanSetCache_.expose(index);
                 break;
             case variable_type::string:
-                stringInputs_.expose(index);
+                stringSetCache_.expose(index);
                 break;
         }
     }
 
     void set_real(variable_index index, double value)
     {
-        realInputs_.set(index, value);
+        realSetCache_.set(index, value);
     }
 
     void set_integer(variable_index index, int value)
     {
-        integerInputs_.set(index, value);
+        integerSetCache_.set(index, value);
     }
 
     void set_boolean(variable_index index, bool value)
     {
-        booleanInputs_.set(index, value);
+        booleanSetCache_.set(index, value);
     }
 
     void set_string(variable_index index, std::string_view value)
     {
-        stringInputs_.set(index, value);
+        stringSetCache_.set(index, value);
     }
 
     boost::fibers::future<void> setup(
@@ -185,26 +185,26 @@ public:
         // clang-format off
         return boost::fibers::async([=]() {
             slave_->set_variables(
-                    gsl::make_span(realInputs_.indexes),
-                    gsl::make_span(realInputs_.values),
-                    gsl::make_span(integerInputs_.indexes),
-                    gsl::make_span(integerInputs_.values),
-                    gsl::make_span(booleanInputs_.indexes),
-                    gsl::make_span(booleanInputs_.values),
-                    gsl::make_span(stringInputs_.indexes),
-                    gsl::make_span(stringInputs_.values)
+                    gsl::make_span(realSetCache_.indexes),
+                    gsl::make_span(realSetCache_.values),
+                    gsl::make_span(integerSetCache_.indexes),
+                    gsl::make_span(integerSetCache_.values),
+                    gsl::make_span(booleanSetCache_.indexes),
+                    gsl::make_span(booleanSetCache_.values),
+                    gsl::make_span(stringSetCache_.indexes),
+                    gsl::make_span(stringSetCache_.values)
                 ).get();
             const auto result = slave_->do_step(currentT, deltaT).get();
             const auto values = slave_->get_variables(
-                    gsl::make_span(realOutputs_.indexes),
-                    gsl::make_span(integerOutputs_.indexes),
-                    gsl::make_span(booleanOutputs_.indexes),
-                    gsl::make_span(stringOutputs_.indexes)
+                    gsl::make_span(realGetCache_.indexes),
+                    gsl::make_span(integerGetCache_.indexes),
+                    gsl::make_span(booleanGetCache_.indexes),
+                    gsl::make_span(stringGetCache_.indexes)
                 ).get();
-            copy_contents(values.real,    realOutputs_.values);
-            copy_contents(values.integer, integerOutputs_.values);
-            copy_contents(values.boolean, booleanOutputs_.values);
-            copy_contents(values.string,  stringOutputs_.values);
+            copy_contents(values.real,    realGetCache_.values);
+            copy_contents(values.integer, integerGetCache_.values);
+            copy_contents(values.boolean, booleanGetCache_.values);
+            copy_contents(values.string,  stringGetCache_.values);
             return result;
         });
         // clang-format on
@@ -215,15 +215,15 @@ private:
     std::string name_;
     cse::model_description modelDescription_;
 
-    exposed_vars<double> realOutputs_;
-    exposed_vars<int> integerOutputs_;
-    exposed_vars<bool> booleanOutputs_;
-    exposed_vars<std::string> stringOutputs_;
+    exposed_vars<double> realGetCache_;
+    exposed_vars<int> integerGetCache_;
+    exposed_vars<bool> booleanGetCache_;
+    exposed_vars<std::string> stringGetCache_;
 
-    exposed_vars<double> realInputs_;
-    exposed_vars<int> integerInputs_;
-    exposed_vars<bool> booleanInputs_;
-    exposed_vars<std::string> stringInputs_;
+    exposed_vars<double> realSetCache_;
+    exposed_vars<int> integerSetCache_;
+    exposed_vars<bool> booleanSetCache_;
+    exposed_vars<std::string> stringSetCache_;
 };
 
 
@@ -252,9 +252,9 @@ cse::model_description slave_simulator::model_description() const
 }
 
 
-void slave_simulator::expose_output(variable_type type, variable_index index)
+void slave_simulator::expose_for_getting(variable_type type, variable_index index)
 {
-    pimpl_->expose_output(type, index);
+    pimpl_->expose_for_getting(type, index);
 }
 
 
@@ -282,9 +282,9 @@ std::string_view slave_simulator::get_string(variable_index index) const
 }
 
 
-void slave_simulator::expose_input(variable_type type, variable_index index)
+void slave_simulator::expose_for_setting(variable_type type, variable_index index)
 {
-    pimpl_->expose_input(type, index);
+    pimpl_->expose_for_setting(type, index);
 }
 
 


### PR DESCRIPTION
This resolves issue #69.

I went with `make_gettable()` and `make_settable()` rather than the suggested `make_readable()` and `make_writable()`, to strengthen the association with the `get` and `set` functions. Unfortunately, that also led to the somewhat weird `xxxGettables` and `xxxSettables` variable names, but I can live with that. ;-)