### PR TITLE
Stop linking to libstdc++fs on Linux

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -92,9 +92,6 @@ target_link_libraries(csecorecpp
         gsl
         Threads::Threads
     )
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries(csecorecpp INTERFACE "stdc++fs")
-endif()
 if(WIN32 AND NOT BUILD_SHARED_LIBS)
     set_target_properties(csecorecpp PROPERTIES OUTPUT_NAME "libcsecorecpp")
 endif()


### PR DESCRIPTION
Since we don't use `std::filesystem` anymore, it's not needed.