### PR TITLE
Safely expose variable multiple times

### DIFF
--- a/src/cpp/slave_simulator.cpp
+++ b/src/cpp/slave_simulator.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 
@@ -49,7 +49,7 @@ struct exposed_vars
             return values[it->second];
         } else {
             std::ostringstream oss;
-            oss << "variable_index " << i << " not found in exposed variables. Variables must be exposed before calling get()"
+            oss << "variable_index " << i << " not found in exposed variables. Variables must be exposed before calling get()";
             throw std::out_of_range(oss.str());
         }
     }
@@ -61,7 +61,7 @@ struct exposed_vars
             values[it->second] = v;
         } else {
             std::ostringstream oss;
-            oss << "variable_index " << i << " not found in exposed variables. Variables must be exposed before calling set()"
+            oss << "variable_index " << i << " not found in exposed variables. Variables must be exposed before calling set()";
             throw std::out_of_range(oss.str());
         }
     }


### PR DESCRIPTION
This aims to solve #93 by checking if a variable has already been exposed.

I also decided it would be a good idea to throw a specific error if trying to set or get a variable which has **not** been exposed, as the previous error message was something long the lines of
`Error code 4: invalid unordered_map<K, T> key`