### PR TITLE
Expose real time functions through C api

### DIFF
--- a/include/cse.h
+++ b/include/cse.h
@@ -268,21 +268,9 @@ typedef struct
     cse_time_point current_time;
     cse_execution_state state;
     int error_code;
+    double real_time_factor;
+    int is_real_time_simulation;
 } cse_execution_status;
-
-#define SLAVE_NAME_MAX_SIZE 1024
-
-typedef struct
-{
-    char name[SLAVE_NAME_MAX_SIZE];
-    char source[SLAVE_NAME_MAX_SIZE];
-    cse_slave_index index;
-} cse_slave_info;
-
-size_t cse_execution_get_num_slaves(cse_execution* execution);
-
-int cse_execution_get_slave_infos(cse_execution* execution, cse_slave_info infos[], size_t numSlaves);
-
 
 /**
  *  \brief
@@ -300,6 +288,26 @@ int cse_execution_get_slave_infos(cse_execution* execution, cse_slave_info infos
 int cse_execution_get_status(
     cse_execution* execution,
     cse_execution_status* status);
+
+#define SLAVE_NAME_MAX_SIZE 1024
+
+typedef struct
+{
+    char name[SLAVE_NAME_MAX_SIZE];
+    char source[SLAVE_NAME_MAX_SIZE];
+    cse_slave_index index;
+} cse_slave_info;
+
+size_t cse_execution_get_num_slaves(cse_execution* execution);
+
+int cse_execution_get_slave_infos(cse_execution* execution, cse_slave_info infos[], size_t numSlaves);
+
+
+/// Enables real time simulation
+int cse_execution_enable_real_time_simulation(cse_execution* execution);
+
+/// Disables real time simulation
+int cse_execution_disable_real_time_simulation(cse_execution* execution);
 
 
 // Observer

--- a/src/cpp/execution.cpp
+++ b/src/cpp/execution.cpp
@@ -185,7 +185,8 @@ private:
             oss << "Cannot find variable with index " << variable.index
                 << ", causality " << cse::to_text(causality)
                 << " and type " << cse::to_text(variable.type)
-                << " for simulator " << variable.simulator;
+                << " for simulator with index " << variable.simulator
+                << " and name " << simulators_.at(variable.simulator)->name();
             throw std::out_of_range(oss.str());
         }
     }

--- a/test/c/real_time_test.c
+++ b/test/c/real_time_test.c
@@ -49,7 +49,7 @@ int main()
     }
 
     double stepSize = 0.1;
-    int64_t nanoStepSize = (int64_t) (stepSize*1.0e9);
+    int64_t nanoStepSize = (int64_t)(stepSize * 1.0e9);
 
     cse_execution* execution = cse_execution_create(0, nanoStepSize);
 
@@ -67,11 +67,20 @@ int main()
     cse_execution_add_slave(execution, slave1);
     cse_execution_add_slave(execution, slave2);
 
-
+    cse_execution_status executionStatus;
+    rc = cse_execution_get_status(execution, &executionStatus);
+    if (rc < 0) {
+        print_last_error();
+        cse_execution_destroy(execution);
+        return 1;
+    }
+    if (!executionStatus.is_real_time_simulation) {
+        cse_execution_enable_real_time_simulation(execution);
+    }
 
     cse_execution_start(execution);
     int64_t before1 = GetCurrentTime();
-    Sleep(5000);
+    Sleep(2000);
     cse_execution_stop(execution);
     int64_t after1 = GetCurrentTime();
 
@@ -79,7 +88,7 @@ int main()
 
     cse_execution_start(execution);
     int64_t before2 = GetCurrentTime();
-    Sleep(5000);
+    Sleep(2000);
     cse_execution_stop(execution);
     int64_t after2 = GetCurrentTime();
 
@@ -89,7 +98,6 @@ int main()
     int rounded = (int)(0.5 + elapsedS / stepSize);
     double elapsed = rounded * stepSize;
 
-    cse_execution_status executionStatus;
     rc = cse_execution_get_status(execution, &executionStatus);
     if (rc < 0) {
         print_last_error();


### PR DESCRIPTION
This covers issue #121.
`real_time_factor` and `is_real_time_simulation` statuses are exposed through `cse_execution_status`, and the methods enabling/disabling real time execution have been added to the C api.