### PR TITLE
Move integration tests to the correct test block

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(tests
     "async_slave_mockup_test"
     "fixed_step_algorithm_test"
+    "file_observer_logging_test"
+    "membuffer_observer_test"
+    "ssp_parser_test"
+    "trend_buffer_test"
 )
 set(unittests
     "fmi_v1_fmu_unittest"
@@ -10,10 +14,6 @@ set(unittests
     "utility_filesystem_unittest"
     "utility_uuid_unittest"
     "utility_zip_unittest"
-    "file_observer_logging_test"
-    "trend_buffer_test"
-    "membuffer_observer_test"
-    "ssp_parser_test"
 )
 
 include("AddTestExecutable")
@@ -23,6 +23,7 @@ foreach(test IN LISTS tests)
         FOLDER "C++ tests"
         SOURCES "${test}.cpp"
         DEPENDENCIES csecorecpp
+        DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../data"
     )
 endforeach()
 


### PR DESCRIPTION
The difference between the tests in the `tests` block and the ones in the `unittests` block is that the latter are linked to Boost.Test and have access to the private headers (so they too can be unittested). The former ("integration tests"?) only have access to the public API, and do not use Boost.Test.