### PR TITLE
#133 Reverted to using build dir as target folder for logs

### DIFF
--- a/test/cpp/file_observer_logging_test.cpp
+++ b/test/cpp/file_observer_logging_test.cpp
@@ -25,7 +25,7 @@ int main()
 
         const auto logPath = boost::filesystem::current_path() / "logs";
         boost::filesystem::path csvPath = boost::filesystem::path(logPath);
-        boost::filesystem::path binPath = boost::filesystem::path(logPath);
+        //boost::filesystem::path binPath = boost::filesystem::path(logPath);
 
         cse::log::set_global_output_level(cse::log::level::debug);
 


### PR DESCRIPTION
Reverted the file logger test to use output folder as target for logs instead of source (this was how it was working previously). 