### PR TITLE
Set a relative RPATH for standalone installations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON
 option(CSECORE_BUILD_TESTS "Build test suite" ON)
 option(CSECORE_BUILD_APIDOC "Build API documentation" ON)
 option(CSECORE_BUILD_PRIVATE_APIDOC "Build private API documentation" OFF)
+option(CSECORE_STANDALONE_INSTALLATION "Whether to build for a standalone installation (Linux only; sets a relative RPATH)" OFF)
 option(CSECORE_USING_CONAN "Whether Conan is used for package management" OFF)
 
 # ==============================================================================

--- a/src/c/CMakeLists.txt
+++ b/src/c/CMakeLists.txt
@@ -20,6 +20,9 @@ target_link_libraries(csecorec PUBLIC csecorecpp)
 if(WIN32 AND NOT BUILD_SHARED_LIBS)
     set_target_properties(csecorec PROPERTIES OUTPUT_NAME "libcsecorec")
 endif()
+if(CSECORE_STANDALONE_INSTALLATION)
+    set_target_properties(csecorec PROPERTIES INSTALL_RPATH "\$ORIGIN")
+endif()
 
 install(
     TARGETS csecorec

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -96,6 +96,9 @@ endif()
 if(WIN32 AND NOT BUILD_SHARED_LIBS)
     set_target_properties(csecorecpp PROPERTIES OUTPUT_NAME "libcsecorecpp")
 endif()
+if(CSECORE_STANDALONE_INSTALLATION)
+    set_target_properties(csecorecpp PROPERTIES INSTALL_RPATH "\$ORIGIN")
+endif()
 
 install(
     TARGETS csecorecpp


### PR DESCRIPTION
This PR was motivated by a Slack discussion with @hplatou.

To enable stand-alone installations of CSE on Linux, that is, installations outside the standard `/usr` tree, it is necessary to modify the dynamic linker search path so it searches for the libraries in the right place.

In practice, this means setting the ELF attribute `RPATH` to `$ORIGIN` for `csecorec.so`, assuming that its dependency `csecorecpp.so` gets installed to the same directory. I also did the same for `csecorecpp.so` in case we want to put any of *its* dependencies there too.

Since this is a non-standard way of going about it, I made it so that the `CSECORE_STANDALONE_INSTALLATION` CMake option must be explicitly enabled for this to take effect.

The RPATH for `cse-server-go` must be set elsewhere and point to the directory that contains `csecorec.so`.