### PR TITLE
Feature/145 optional boost tests dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 
 set(Boost_components date_time fiber filesystem log)
 if (CSECORE_BUILD_TESTS)
-    list(APPEND Boost_components unit_test_framework
+    list(APPEND Boost_components unit_test_framework)
 endif()
 
 find_package(GSL REQUIRED)


### PR DESCRIPTION
Minor update. Boost-test should not be required when not building tests. 