### PR TITLE
Add fmilib_shared to search names

### DIFF
--- a/cmake/FindFMILibrary.cmake
+++ b/cmake/FindFMILibrary.cmake
@@ -37,7 +37,7 @@ if (UNIX)
     set (CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 endif ()
 find_library (FMILibrary_LIBRARY
-    NAMES "fmilib2" "fmilib"
+    NAMES "fmilib2" "fmilib" "fmilib_shared"
     PATHS ${FMILibrary_DIR} $ENV{FMILibrary_DIR}
     PATH_SUFFIXES "lib")
 mark_as_advanced (FMILibrary_LIBRARY)


### PR DESCRIPTION
FindFMILibrary is missing a commonly used library name for fmilib. This PR adds it, allowing fmilib to be found on manual windows and vcpkg builds.