### PR TITLE
Fix issue #158, "How to build is incomplete"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ Then, acquire dependencies with Conan:
 
     conan install .. --build=missing
 
-Now, we can run CMake to generate the build system.  For **Visual Studio**,
-enter:
+Now, we can run CMake to generate the build system.  (If you have not installed
+Doxygen at this point, append `-DCSECORE_BUILD_APIDOC=OFF` to the next command
+to disable API documentation generation.)
+
+For **Visual Studio**, enter:
 
     cmake .. -DCSECORE_USING_CONAN=TRUE -G "Visual Studio 15 2017 Win64"
 


### PR DESCRIPTION
Doxygen was already listed (as optional) in the "Required tools" section. This PR adds a note on how to disable doc generation if the user chooses not to install it.