### PR TITLE
Specify scm url using ssh

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class CSECoreConan(ConanFile):
     author = "osp"
     scm = {
         "type": "git",
-        "url": "auto",
+        "url": "git@github.com:open-simulation-platform/cse-core.git",
         "revision": "auto"
     }
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
Aims to fix #193 by changing the specification of the scm url in conanfile.

To test this with the cse-server-go build you will have to edit 'conanfile.txt' and change the require section to point to the artifacts from this branch:

```
[requires]
cse-core/0.1.0@osp/193-use-ssh-for-github-url-in-conan
```