### PR TITLE
Make sure to run target 'install-doc' as part of building conan package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -51,4 +51,6 @@ class CSECoreConan(ConanFile):
 
     def package(self):
         cmake = self.configure_cmake()
+        self.run('cmake --build %s --target install-doc' % (self.build_folder))
         cmake.install()
+        


### PR DESCRIPTION
Adding target 'install-doc' to include doc in build artifact. Please check that build artifact on Jenkins contains Doxygen doc. Fixes #199 