### PR TITLE
Workaround to enable Linux RelWithDebInfo builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 
 set(Boost_components date_time fiber filesystem log)
 if (CSECORE_BUILD_TESTS)
-    list(APPEND Boost_components unit_test_framework)
+    list(APPEND Boost_components timer unit_test_framework)
 endif()
 
 find_package(GSL REQUIRED)

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -37,7 +37,7 @@ foreach(test IN LISTS unittests)
         "cpp_${test}"
         FOLDER "C++ unit tests"
         SOURCES "${test}.cpp"
-        DEPENDENCIES csecorecpp "Boost::unit_test_framework"
+        DEPENDENCIES csecorecpp "Boost::unit_test_framework" "Boost::timer"
         DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../data"
     )
     target_include_directories("cpp_${test}" PRIVATE "$<TARGET_PROPERTY:csecorecpp,SOURCE_DIR>")


### PR DESCRIPTION
For some reason, `libboost_unit_test_framework.so` depends on `libboost_timer.so` when building with the `RelWithDebInfo` configuration on Linux. This does not appear to be the case in `Debug` or `Release` mode. This is probably a bug in either CMake's FindBoost script or in Conan's Boost package.  I don't think we are causing it ourselves.  Here, I've added Boost.Timer as an explicit dependency in order to work around the issue.