### PR TITLE
Manipulator documentation

### DIFF
--- a/include/cse/algorithm.hpp
+++ b/include/cse/algorithm.hpp
@@ -81,34 +81,74 @@ public:
      */
     virtual void set_string(variable_index index, std::string_view value) = 0;
 
+    /**
+     *  Sets a manipulator for the value of a real input variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_real_input_manipulator(
         variable_index index,
         std::function<double(double)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of an integer input variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_integer_input_manipulator(
         variable_index index,
         std::function<int(int)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of a boolean input variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_boolean_input_manipulator(
         variable_index index,
         std::function<bool(bool)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of a string input variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_string_input_manipulator(
         variable_index index,
         std::function<std::string(std::string_view)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of a real output variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_real_output_manipulator(
         variable_index index,
         std::function<double(double)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of an integer output variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_integer_output_manipulator(
         variable_index index,
         std::function<int(int)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of a boolean output variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_boolean_output_manipulator(
         variable_index index,
         std::function<bool(bool)> manipulator) = 0;
 
+    /**
+     *  Sets a manipulator for the value of a string output variable.
+     *
+     *  The variable must previously have been exposed with `expose_for_setting()`.
+     */
     virtual void set_string_output_manipulator(
         variable_index index,
         std::function<std::string(std::string_view)> manipulator) = 0;

--- a/include/cse/manipulator.hpp
+++ b/include/cse/manipulator.hpp
@@ -19,6 +19,13 @@
 namespace cse
 {
 
+/**
+ *  An interface for manipulators.
+ *
+ *  The methods in this interface represent various events that the manipulator
+ *  may react to in some way. It may manipulate the slaves' variable values
+ *  through the `simulator` interface at any time.
+ */
 class manipulator
 {
 public:
@@ -35,6 +42,9 @@ public:
     virtual ~manipulator() noexcept {}
 };
 
+/**
+ *  A manipulator implementation handling execution and control of scenarios.
+ */
 class scenario_manager : public manipulator
 {
 public:
@@ -59,16 +69,22 @@ public:
     /**
      * Load a scenario for execution.
      *
-     * @param s The in-memory constructed scenario.
-     * @param currentTime The time point at which the scenario will start.
+     * \param s
+     *  The in-memory constructed scenario.
+     * \param currentTime
+     *  The time point at which the scenario will start. The scenario's events
+     *  will be executed relative to this time point.
      */
     void load_scenario(const scenario::scenario& s, time_point currentTime);
 
     /**
      * Load a scenario for execution.
      *
-     * @param scenarioFile The path to a proprietary `json` file defining the scenario.
-     * @param currentTime The time point at which the scenario will start.
+     * \param scenarioFile
+     *  The path to a proprietary `json` file defining the scenario.
+     * \param currentTime
+     *  The time point at which the scenario will start. The scenario's events
+     *  will be executed relative to this time point.
      */
     void load_scenario(const boost::filesystem::path& scenarioFile, time_point currentTime);
 
@@ -83,6 +99,9 @@ private:
     std::unique_ptr<impl> pimpl_;
 };
 
+/**
+ *  A manipulator implementation handling overrides of variable values.
+ */
 class override_manipulator : public manipulator
 {
 public:
@@ -116,7 +135,11 @@ private:
         simulator_index index,
         variable_index variable,
         variable_type type,
-        const scenario::manipulators& m);
+        const std::variant<
+            scenario::real_manipulator,
+            scenario::integer_manipulator,
+            scenario::boolean_manipulator,
+            scenario::string_manipulator>& m);
 
     std::unordered_map<simulator_index, simulator*> simulators_;
     std::vector<scenario::variable_action> actions_;

--- a/include/cse/scenario.hpp
+++ b/include/cse/scenario.hpp
@@ -15,49 +15,71 @@ namespace cse
 namespace scenario
 {
 
+/// The modification of the value of a variable with type `real`.
 struct real_manipulator
 {
+    /// A function which may be called any number of times. Can be `nullptr`.
     std::function<double(double)> f;
 };
 
+/// The modification of the value of a variable with type `integer`.
 struct integer_manipulator
 {
+    /// A function which may be called any number of times. Can be `nullptr`.
     std::function<int(int)> f;
 };
 
+/// The modification of the value of a variable with type `boolean`.
 struct boolean_manipulator
 {
+    /// A function which may be called any number of times. Can be `nullptr`.
     std::function<bool(bool)> f;
 };
 
+/// The modification of the value of a variable with type `string`.
 struct string_manipulator
 {
+    /// A function which may be called any number of times. Can be `nullptr`.
     std::function<std::string(std::string_view)> f;
 };
 
-using manipulators = std::variant<
-    real_manipulator,
-    integer_manipulator,
-    boolean_manipulator,
-    string_manipulator>;
-
+/// A struct specifying a variable and the modification of its value.
 struct variable_action
 {
+    /// The simulator index.
     simulator_index simulator;
+    /// The variable index.
     variable_index variable;
-    manipulators manipulator;
+    /// The modification to be done to the variable's value.
+    std::variant<
+        real_manipulator,
+        integer_manipulator,
+        boolean_manipulator,
+        string_manipulator>
+        manipulator;
+    /**
+     * Flag which should be set to `true` if the variable is an *input* to the
+     * slave (i.e. causality input or parameter), or `false` if the variable is
+     * an *output* from a slave (i.e. causality output or calculatedParameter).
+     */
     bool is_input;
 };
 
+/// A struct representing an event.
 struct event
 {
+    /// The time point at which the event should trigger.
     time_point time;
+    /// Something which should happen to a variable.
     variable_action action;
 };
 
+/// A struct representing an executable scenario.
 struct scenario
 {
+    /// A collection of time-based events.
     std::vector<event> events;
+    /// An optional time point at which the scenario should terminate.
     std::optional<time_point> end;
 };
 

--- a/include/cse/scenario_parser.hpp
+++ b/include/cse/scenario_parser.hpp
@@ -8,7 +8,18 @@
 
 namespace cse
 {
-scenario::scenario parse_scenario(const boost::filesystem::path& scenarioFile, const std::unordered_map<simulator_index, simulator*>& simulators);
-}
+/**
+ * Parses a scenario from file.
+ *
+ * \param scenarioFile
+ *  The path to a proprietary `json` file defining the scenario.
+ *
+ * \param simulators
+ *  A map containing the simulators currently loaded in the execution.
+ */
+scenario::scenario parse_scenario(
+    const boost::filesystem::path& scenarioFile,
+    const std::unordered_map<simulator_index, simulator*>& simulators);
+} // namespace cse
 
 #endif //CSECORE_SCENARIO_PARSER_H

--- a/src/cpp/override_manipulator.cpp
+++ b/src/cpp/override_manipulator.cpp
@@ -115,7 +115,11 @@ void override_manipulator::add_action(
     simulator_index index,
     variable_index variable,
     variable_type type,
-    const scenario::manipulators& m)
+    const std::variant<
+        scenario::real_manipulator,
+        scenario::integer_manipulator,
+        scenario::boolean_manipulator,
+        scenario::string_manipulator>& m)
 {
     auto sim = simulators_.at(index);
     auto causality = find_variable_causality(sim->model_description().variables, type, variable);


### PR DESCRIPTION
This solves #207, lacking API documentation for cse/manipulator.hpp. Also added some documentation to "nearby" classes where documentation was missing.