### PR TITLE
Rename manipulator to modifier

### DIFF
--- a/include/cse/algorithm.hpp
+++ b/include/cse/algorithm.hpp
@@ -82,76 +82,76 @@ public:
     virtual void set_string(variable_index index, std::string_view value) = 0;
 
     /**
-     *  Sets a manipulator for the value of a real input variable.
+     *  Sets a modifier for the value of a real input variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_real_input_manipulator(
+    virtual void set_real_input_modifier(
         variable_index index,
-        std::function<double(double)> manipulator) = 0;
+        std::function<double(double)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of an integer input variable.
+     *  Sets a modifier for the value of an integer input variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_integer_input_manipulator(
+    virtual void set_integer_input_modifier(
         variable_index index,
-        std::function<int(int)> manipulator) = 0;
+        std::function<int(int)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of a boolean input variable.
+     *  Sets a modifier for the value of a boolean input variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_boolean_input_manipulator(
+    virtual void set_boolean_input_modifier(
         variable_index index,
-        std::function<bool(bool)> manipulator) = 0;
+        std::function<bool(bool)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of a string input variable.
+     *  Sets a modifier for the value of a string input variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_string_input_manipulator(
+    virtual void set_string_input_modifier(
         variable_index index,
-        std::function<std::string(std::string_view)> manipulator) = 0;
+        std::function<std::string(std::string_view)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of a real output variable.
+     *  Sets a modifier for the value of a real output variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_real_output_manipulator(
+    virtual void set_real_output_modifier(
         variable_index index,
-        std::function<double(double)> manipulator) = 0;
+        std::function<double(double)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of an integer output variable.
+     *  Sets a modifier for the value of an integer output variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_integer_output_manipulator(
+    virtual void set_integer_output_modifier(
         variable_index index,
-        std::function<int(int)> manipulator) = 0;
+        std::function<int(int)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of a boolean output variable.
+     *  Sets a modifier for the value of a boolean output variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_boolean_output_manipulator(
+    virtual void set_boolean_output_modifier(
         variable_index index,
-        std::function<bool(bool)> manipulator) = 0;
+        std::function<bool(bool)> modifier) = 0;
 
     /**
-     *  Sets a manipulator for the value of a string output variable.
+     *  Sets a modifier for the value of a string output variable.
      *
      *  The variable must previously have been exposed with `expose_for_setting()`.
      */
-    virtual void set_string_output_manipulator(
+    virtual void set_string_output_modifier(
         variable_index index,
-        std::function<std::string(std::string_view)> manipulator) = 0;
+        std::function<std::string(std::string_view)> modifier) = 0;
 
     /**
      *  Performs pre-simulation setup and enters initialisation mode.

--- a/include/cse/manipulator.hpp
+++ b/include/cse/manipulator.hpp
@@ -23,7 +23,7 @@ namespace cse
  *  An interface for manipulators.
  *
  *  The methods in this interface represent various events that the manipulator
- *  may react to in some way. It may manipulate the slaves' variable values
+ *  may react to in some way. It may modify the slaves' variable values
  *  through the `simulator` interface at any time.
  */
 class manipulator
@@ -136,10 +136,10 @@ private:
         variable_index variable,
         variable_type type,
         const std::variant<
-            scenario::real_manipulator,
-            scenario::integer_manipulator,
-            scenario::boolean_manipulator,
-            scenario::string_manipulator>& m);
+            scenario::real_modifier,
+            scenario::integer_modifier,
+            scenario::boolean_modifier,
+            scenario::string_modifier>& m);
 
     std::unordered_map<simulator_index, simulator*> simulators_;
     std::vector<scenario::variable_action> actions_;

--- a/include/cse/scenario.hpp
+++ b/include/cse/scenario.hpp
@@ -16,28 +16,28 @@ namespace scenario
 {
 
 /// The modification of the value of a variable with type `real`.
-struct real_manipulator
+struct real_modifier
 {
     /// A function which may be called any number of times. Can be `nullptr`.
     std::function<double(double)> f;
 };
 
 /// The modification of the value of a variable with type `integer`.
-struct integer_manipulator
+struct integer_modifier
 {
     /// A function which may be called any number of times. Can be `nullptr`.
     std::function<int(int)> f;
 };
 
 /// The modification of the value of a variable with type `boolean`.
-struct boolean_manipulator
+struct boolean_modifier
 {
     /// A function which may be called any number of times. Can be `nullptr`.
     std::function<bool(bool)> f;
 };
 
 /// The modification of the value of a variable with type `string`.
-struct string_manipulator
+struct string_modifier
 {
     /// A function which may be called any number of times. Can be `nullptr`.
     std::function<std::string(std::string_view)> f;
@@ -52,11 +52,11 @@ struct variable_action
     variable_index variable;
     /// The modification to be done to the variable's value.
     std::variant<
-        real_manipulator,
-        integer_manipulator,
-        boolean_manipulator,
-        string_manipulator>
-        manipulator;
+        real_modifier,
+        integer_modifier,
+        boolean_modifier,
+        string_modifier>
+        modifier;
     /**
      * Flag which should be set to `true` if the variable is an *input* to the
      * slave (i.e. causality input or parameter), or `false` if the variable is

--- a/src/cpp/cse/slave_simulator.hpp
+++ b/src/cpp/cse/slave_simulator.hpp
@@ -46,30 +46,30 @@ public:
     void set_boolean(variable_index index, bool value) override;
     void set_string(variable_index index, std::string_view value) override;
 
-    void set_real_input_manipulator(
+    void set_real_input_modifier(
         variable_index index,
-        std::function<double(double)> manipulator) override;
-    void set_integer_input_manipulator(
+        std::function<double(double)> modifier) override;
+    void set_integer_input_modifier(
         variable_index index,
-        std::function<int(int)> manipulator) override;
-    void set_boolean_input_manipulator(
+        std::function<int(int)> modifier) override;
+    void set_boolean_input_modifier(
         variable_index index,
-        std::function<bool(bool)> manipulator) override;
-    void set_string_input_manipulator(
+        std::function<bool(bool)> modifier) override;
+    void set_string_input_modifier(
         variable_index index,
-        std::function<std::string(std::string_view)> manipulator) override;
-    void set_real_output_manipulator(
+        std::function<std::string(std::string_view)> modifier) override;
+    void set_real_output_modifier(
         variable_index index,
-        std::function<double(double)> manipulator) override;
-    void set_integer_output_manipulator(
+        std::function<double(double)> modifier) override;
+    void set_integer_output_modifier(
         variable_index index,
-        std::function<int(int)> manipulator) override;
-    void set_boolean_output_manipulator(
+        std::function<int(int)> modifier) override;
+    void set_boolean_output_modifier(
         variable_index index,
-        std::function<bool(bool)> manipulator) override;
-    void set_string_output_manipulator(
+        std::function<bool(bool)> modifier) override;
+    void set_string_output_modifier(
         variable_index index,
-        std::function<std::string(std::string_view)> manipulator) override;
+        std::function<std::string(std::string_view)> modifier) override;
 
     boost::fibers::future<void> setup(
         time_point startTime,

--- a/src/cpp/override_manipulator.cpp
+++ b/src/cpp/override_manipulator.cpp
@@ -41,7 +41,7 @@ bool is_input(cse::variable_causality causality)
             return false;
         default:
             throw std::invalid_argument(
-                "No support for manipulating a variable with this causality");
+                "No support for modifying a variable with this causality");
     }
 }
 
@@ -69,43 +69,43 @@ void override_manipulator::step_commencing(time_point /*currentTime*/)
             auto sim = simulators_.at(a.simulator);
             std::visit(
                 visitor(
-                    [=](scenario::real_manipulator m) {
+                    [=](scenario::real_modifier m) {
                         if (a.is_input) {
                             sim->expose_for_setting(variable_type::real, a.variable);
-                            sim->set_real_input_manipulator(a.variable, m.f);
+                            sim->set_real_input_modifier(a.variable, m.f);
                         } else {
                             sim->expose_for_getting(variable_type::real, a.variable);
-                            sim->set_real_output_manipulator(a.variable, m.f);
+                            sim->set_real_output_modifier(a.variable, m.f);
                         }
                     },
-                    [=](scenario::integer_manipulator m) {
+                    [=](scenario::integer_modifier m) {
                         if (a.is_input) {
                             sim->expose_for_setting(variable_type::integer, a.variable);
-                            sim->set_integer_input_manipulator(a.variable, m.f);
+                            sim->set_integer_input_modifier(a.variable, m.f);
                         } else {
                             sim->expose_for_getting(variable_type::integer, a.variable);
-                            sim->set_integer_output_manipulator(a.variable, m.f);
+                            sim->set_integer_output_modifier(a.variable, m.f);
                         }
                     },
-                    [=](scenario::boolean_manipulator m) {
+                    [=](scenario::boolean_modifier m) {
                         if (a.is_input) {
                             sim->expose_for_setting(variable_type::boolean, a.variable);
-                            sim->set_boolean_input_manipulator(a.variable, m.f);
+                            sim->set_boolean_input_modifier(a.variable, m.f);
                         } else {
                             sim->expose_for_getting(variable_type::boolean, a.variable);
-                            sim->set_boolean_output_manipulator(a.variable, m.f);
+                            sim->set_boolean_output_modifier(a.variable, m.f);
                         }
                     },
-                    [=](scenario::string_manipulator m) {
+                    [=](scenario::string_modifier m) {
                         if (a.is_input) {
                             sim->expose_for_setting(variable_type::string, a.variable);
-                            sim->set_string_input_manipulator(a.variable, m.f);
+                            sim->set_string_input_modifier(a.variable, m.f);
                         } else {
                             sim->expose_for_getting(variable_type::string, a.variable);
-                            sim->set_string_output_manipulator(a.variable, m.f);
+                            sim->set_string_output_modifier(a.variable, m.f);
                         }
                     }),
-                a.manipulator);
+                a.modifier);
         }
         actions_.clear();
     }
@@ -116,10 +116,10 @@ void override_manipulator::add_action(
     variable_index variable,
     variable_type type,
     const std::variant<
-        scenario::real_manipulator,
-        scenario::integer_manipulator,
-        scenario::boolean_manipulator,
-        scenario::string_manipulator>& m)
+        scenario::real_modifier,
+        scenario::integer_modifier,
+        scenario::boolean_modifier,
+        scenario::string_modifier>& m)
 {
     auto sim = simulators_.at(index);
     auto causality = find_variable_causality(sim->model_description().variables, type, variable);
@@ -135,7 +135,7 @@ void override_manipulator::override_real_variable(
     double value)
 {
     auto f = [value](double /*original*/) { return value; };
-    add_action(index, variable, variable_type::real, scenario::real_manipulator{f});
+    add_action(index, variable, variable_type::real, scenario::real_modifier{f});
 }
 
 void override_manipulator::override_integer_variable(
@@ -144,7 +144,7 @@ void override_manipulator::override_integer_variable(
     int value)
 {
     auto f = [value](int /*original*/) { return value; };
-    add_action(index, variable, variable_type::integer, scenario::integer_manipulator{f});
+    add_action(index, variable, variable_type::integer, scenario::integer_modifier{f});
 }
 
 void override_manipulator::override_boolean_variable(
@@ -153,7 +153,7 @@ void override_manipulator::override_boolean_variable(
     bool value)
 {
     auto f = [value](bool /*original*/) { return value; };
-    add_action(index, variable, variable_type::boolean, scenario::boolean_manipulator{f});
+    add_action(index, variable, variable_type::boolean, scenario::boolean_modifier{f});
 }
 
 void override_manipulator::override_string_variable(
@@ -162,35 +162,35 @@ void override_manipulator::override_string_variable(
     const std::string& value)
 {
     auto f = [value](std::string_view /*original*/) { return value; };
-    add_action(index, variable, variable_type::string, scenario::string_manipulator{f});
+    add_action(index, variable, variable_type::string, scenario::string_modifier{f});
 }
 
 void override_manipulator::reset_real_variable(
     simulator_index index,
     variable_index variable)
 {
-    add_action(index, variable, variable_type::real, scenario::real_manipulator{nullptr});
+    add_action(index, variable, variable_type::real, scenario::real_modifier{nullptr});
 }
 
 void override_manipulator::reset_integer_variable(
     simulator_index index,
     variable_index variable)
 {
-    add_action(index, variable, variable_type::integer, scenario::integer_manipulator{nullptr});
+    add_action(index, variable, variable_type::integer, scenario::integer_modifier{nullptr});
 }
 
 void override_manipulator::reset_boolean_variable(
     simulator_index index,
     variable_index variable)
 {
-    add_action(index, variable, variable_type::boolean, scenario::boolean_manipulator{nullptr});
+    add_action(index, variable, variable_type::boolean, scenario::boolean_modifier{nullptr});
 }
 
 void override_manipulator::reset_string_variable(
     simulator_index index,
     variable_index variable)
 {
-    add_action(index, variable, variable_type::string, scenario::string_manipulator{nullptr});
+    add_action(index, variable, variable_type::string, scenario::string_modifier{nullptr});
 }
 
 override_manipulator::~override_manipulator() = default;

--- a/src/cpp/scenario_manager.cpp
+++ b/src/cpp/scenario_manager.cpp
@@ -130,43 +130,43 @@ private:
     {
         std::visit(
             visitor(
-                [=](scenario::real_manipulator m) {
+                [=](scenario::real_modifier m) {
                     if (a.is_input) {
                         sim->expose_for_setting(variable_type::real, a.variable);
-                        sim->set_real_input_manipulator(a.variable, m.f);
+                        sim->set_real_input_modifier(a.variable, m.f);
                     } else {
                         sim->expose_for_getting(variable_type::real, a.variable);
-                        sim->set_real_output_manipulator(a.variable, m.f);
+                        sim->set_real_output_modifier(a.variable, m.f);
                     }
                 },
-                [=](scenario::integer_manipulator m) {
+                [=](scenario::integer_modifier m) {
                     if (a.is_input) {
                         sim->expose_for_setting(variable_type::integer, a.variable);
-                        sim->set_integer_input_manipulator(a.variable, m.f);
+                        sim->set_integer_input_modifier(a.variable, m.f);
                     } else {
                         sim->expose_for_getting(variable_type::integer, a.variable);
-                        sim->set_integer_output_manipulator(a.variable, m.f);
+                        sim->set_integer_output_modifier(a.variable, m.f);
                     }
                 },
-                [=](scenario::boolean_manipulator m) {
+                [=](scenario::boolean_modifier m) {
                     if (a.is_input) {
                         sim->expose_for_setting(variable_type::boolean, a.variable);
-                        sim->set_boolean_input_manipulator(a.variable, m.f);
+                        sim->set_boolean_input_modifier(a.variable, m.f);
                     } else {
                         sim->expose_for_getting(variable_type::boolean, a.variable);
-                        sim->set_boolean_output_manipulator(a.variable, m.f);
+                        sim->set_boolean_output_modifier(a.variable, m.f);
                     }
                 },
-                [=](scenario::string_manipulator m) {
+                [=](scenario::string_modifier m) {
                     if (a.is_input) {
                         sim->expose_for_setting(variable_type::string, a.variable);
-                        sim->set_string_input_manipulator(a.variable, m.f);
+                        sim->set_string_input_modifier(a.variable, m.f);
                     } else {
                         sim->expose_for_getting(variable_type::string, a.variable);
-                        sim->set_string_output_manipulator(a.variable, m.f);
+                        sim->set_string_output_modifier(a.variable, m.f);
                     }
                 }),
-            a.manipulator);
+            a.modifier);
     }
 
     bool maybe_run_event(time_point relativeTime, const scenario::event& e)
@@ -189,35 +189,35 @@ private:
             << ", variable " << a.variable;
         std::visit(
             visitor(
-                [=](scenario::real_manipulator /*m*/) {
+                [=](scenario::real_modifier /*m*/) {
                     if (a.is_input) {
-                        sim->set_real_input_manipulator(a.variable, nullptr);
+                        sim->set_real_input_modifier(a.variable, nullptr);
                     } else {
-                        sim->set_real_output_manipulator(a.variable, nullptr);
+                        sim->set_real_output_modifier(a.variable, nullptr);
                     }
                 },
-                [=](scenario::integer_manipulator /*m*/) {
+                [=](scenario::integer_modifier /*m*/) {
                     if (a.is_input) {
-                        sim->set_integer_input_manipulator(a.variable, nullptr);
+                        sim->set_integer_input_modifier(a.variable, nullptr);
                     } else {
-                        sim->set_integer_output_manipulator(a.variable, nullptr);
+                        sim->set_integer_output_modifier(a.variable, nullptr);
                     }
                 },
-                [=](scenario::boolean_manipulator /*m*/) {
+                [=](scenario::boolean_modifier /*m*/) {
                     if (a.is_input) {
-                        sim->set_boolean_input_manipulator(a.variable, nullptr);
+                        sim->set_boolean_input_modifier(a.variable, nullptr);
                     } else {
-                        sim->set_boolean_output_manipulator(a.variable, nullptr);
+                        sim->set_boolean_output_modifier(a.variable, nullptr);
                     }
                 },
-                [=](scenario::string_manipulator /*m*/) {
+                [=](scenario::string_modifier /*m*/) {
                     if (a.is_input) {
-                        sim->set_string_input_manipulator(a.variable, nullptr);
+                        sim->set_string_input_modifier(a.variable, nullptr);
                     } else {
-                        sim->set_string_output_manipulator(a.variable, nullptr);
+                        sim->set_string_output_modifier(a.variable, nullptr);
                     }
                 }),
-            a.manipulator);
+            a.modifier);
     }
 
     void cleanup(const std::unordered_map<int, scenario::event>& executedEvents)

--- a/src/cpp/scenario_parser.cpp
+++ b/src/cpp/scenario_parser.cpp
@@ -71,7 +71,7 @@ bool is_input(cse::variable_causality causality)
             return false;
         default:
             throw std::invalid_argument(
-                "No support for manipulating a variable with this causality");
+                "No support for modifying a variable with this causality");
     }
 }
 
@@ -90,7 +90,7 @@ cse::variable_index find_variable_index(
 }
 
 template<typename T>
-std::function<T(T)> generate_manipulator(
+std::function<T(T)> generate_modifier(
     const std::string& kind,
     const nlohmann::json& event)
 {
@@ -116,14 +116,14 @@ cse::scenario::variable_action generate_action(
 {
     switch (type) {
         case cse::variable_type::real: {
-            auto f = generate_manipulator<double>(mode, event);
+            auto f = generate_modifier<double>(mode, event);
             return cse::scenario::variable_action{
-                sim, var, cse::scenario::real_manipulator{f}, isInput};
+                sim, var, cse::scenario::real_modifier{f}, isInput};
         }
         case cse::variable_type::integer: {
-            auto f = generate_manipulator<int>(mode, event);
+            auto f = generate_modifier<int>(mode, event);
             return cse::scenario::variable_action{
-                sim, var, cse::scenario::integer_manipulator{f}, isInput};
+                sim, var, cse::scenario::integer_modifier{f}, isInput};
         }
         default:
             throw std::invalid_argument("No support for this variable type");

--- a/test/cpp/scenario_manager_test.cpp
+++ b/test/cpp/scenario_manager_test.cpp
@@ -44,24 +44,24 @@ int main()
         constexpr bool input = true;
         constexpr bool output = false;
 
-        auto realManipulator1 = cse::scenario::real_manipulator{[](double original) { return original + 1.001; }};
-        auto realAction1 = cse::scenario::variable_action{simIndex, 1, realManipulator1, input};
+        auto realModifier1 = cse::scenario::real_modifier{[](double original) { return original + 1.001; }};
+        auto realAction1 = cse::scenario::variable_action{simIndex, 1, realModifier1, input};
         auto realEvent1 = cse::scenario::event{cse::to_time_point(0.5), realAction1};
 
-        auto realManipulator2 = cse::scenario::real_manipulator{[](double /*original*/) { return -1.0; }};
-        auto realAction2 = cse::scenario::variable_action{simIndex, 0, realManipulator2, output};
+        auto realModifier2 = cse::scenario::real_modifier{[](double /*original*/) { return -1.0; }};
+        auto realAction2 = cse::scenario::variable_action{simIndex, 0, realModifier2, output};
         auto realEvent2 = cse::scenario::event{cse::to_time_point(0.2), realAction2};
 
-        auto realManipulator3 = cse::scenario::real_manipulator{nullptr};
-        auto realAction3 = cse::scenario::variable_action{simIndex, 0, realManipulator3, output};
+        auto realModifier3 = cse::scenario::real_modifier{nullptr};
+        auto realAction3 = cse::scenario::variable_action{simIndex, 0, realModifier3, output};
         auto realEvent3 = cse::scenario::event{cse::to_time_point(0.3), realAction3};
 
-        auto intManipulator1 = cse::scenario::integer_manipulator{[](int /*original*/) { return 2; }};
-        auto intAction1 = cse::scenario::variable_action{simIndex, 1, intManipulator1, input};
+        auto intModifier1 = cse::scenario::integer_modifier{[](int /*original*/) { return 2; }};
+        auto intAction1 = cse::scenario::variable_action{simIndex, 1, intModifier1, input};
         auto intEvent1 = cse::scenario::event{cse::to_time_point(0.65), intAction1};
 
-        auto intManipulator2 = cse::scenario::integer_manipulator{[](int /*original*/) { return 5; }};
-        auto intAction2 = cse::scenario::variable_action{simIndex, 0, intManipulator2, output};
+        auto intModifier2 = cse::scenario::integer_modifier{[](int /*original*/) { return 5; }};
+        auto intAction2 = cse::scenario::variable_action{simIndex, 0, intModifier2, output};
         auto intEvent2 = cse::scenario::event{cse::to_time_point(0.8), intAction2};
 
         auto events = std::vector<cse::scenario::event>();


### PR DESCRIPTION
This fixes #196, renaming the low level concept *manipulator* to *modifier*.

Solved in mob session.