### PR TITLE
Make it possible to attach a observer to a ssp generated execution

### DIFF
--- a/include/cse/ssp_parser.hpp
+++ b/include/cse/ssp_parser.hpp
@@ -4,12 +4,13 @@
 
 #include <cse/execution.hpp>
 #include <cse/model.hpp>
+#include <cse/observer.hpp>
 
 #include <boost/filesystem/path.hpp>
 
 #include <map>
+#include <memory>
 #include <string>
-
 
 namespace cse
 {
@@ -23,7 +24,7 @@ struct simulator_map_entry
 
 using simulator_map = std::map<std::string, simulator_map_entry>;
 
-std::pair<execution, simulator_map> load_ssp(const boost::filesystem::path& sspDir, cse::time_point startTime);
+std::pair<execution, simulator_map> load_ssp(const boost::filesystem::path& sspDir, cse::time_point startTime, std::shared_ptr<cse::observer> observer = nullptr);
 
 } // namespace cse
 

--- a/src/cpp/ssp_parser.cpp
+++ b/src/cpp/ssp_parser.cpp
@@ -181,7 +181,7 @@ struct slave_info
 
 } // namespace
 
-std::pair<execution, simulator_map> load_ssp(const boost::filesystem::path& sspDir, cse::time_point startTime)
+std::pair<execution, simulator_map> load_ssp(const boost::filesystem::path& sspDir, cse::time_point startTime, std::shared_ptr<cse::observer> observer)
 {
     simulator_map simulatorMap;
 
@@ -195,6 +195,8 @@ std::pair<execution, simulator_map> load_ssp(const boost::filesystem::path& sspD
     auto execution = cse::execution(
         startTime,
         std::make_unique<cse::fixed_step_algorithm>(stepSize));
+
+    if (observer != nullptr) execution.add_observer(observer);
 
     std::map<std::string, slave_info> slaves;
     auto importer = cse::fmi::importer::create();


### PR DESCRIPTION
Simple backward compatible change. Allows an observer to be passed to the ssp_parser. 

Closes #240 

Edit:

Why do I want this? To be able to retrieve information about parsed simulators. But if there is some better way, this is not so much needed..