### PR TITLE
Print path of requested archive on error

### DIFF
--- a/src/cpp/utility/zip.cpp
+++ b/src/cpp/utility/zip.cpp
@@ -106,7 +106,7 @@ void archive::open(const boost::filesystem::path& path)
         auto msgBuf = std::vector<char>(
             zip_error_to_str(nullptr, 0, errorCode, errnoVal) + 1);
         zip_error_to_str(msgBuf.data(), msgBuf.size(), errorCode, errno);
-        throw error(msgBuf.data());
+        throw error("Unzipping of file: '" + path.string() + "' failed with error: " + msgBuf.data());
     }
     m_archive = archive;
 }


### PR DESCRIPTION
Old output: 
```
Error: ZIP file error: Unzipping of file:  No such file
```
New output: 
```
Error: ZIP file error: Unzipping of file: 'wrong/path/to/my_fmu.fmu' failed with error: No such file
```

Closes #242 