### PR TITLE
#244 removing curly brackets from unpack fmu dir path

### DIFF
--- a/src/cpp/fmi/importer.cpp
+++ b/src/cpp/fmi/importer.cpp
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <new>
 #include <sstream>
-
+#include <string>
 
 namespace cse
 {
@@ -184,7 +184,10 @@ std::string sanitise_path(const std::string& str)
             sanitised << c;
         }
     }
-    return sanitised.str();
+    auto sanitised_string = sanitised.str();
+    sanitised_string.erase(std::remove(sanitised_string.begin(), sanitised_string.end(), '{'), sanitised_string.end());
+    sanitised_string.erase(std::remove(sanitised_string.begin(), sanitised_string.end(), '}'), sanitised_string.end());
+    return sanitised_string;
 }
 } // namespace
 

--- a/test/cpp/fmi_v2_fmu_unittest.cpp
+++ b/test/cpp/fmi_v2_fmu_unittest.cpp
@@ -27,6 +27,7 @@ BOOST_AUTO_TEST_CASE(v2_fmu)
     BOOST_TEST(d->author.empty());
     BOOST_TEST(d->version.empty());
     BOOST_TEST(std::static_pointer_cast<fmi::v2::fmu>(fmu)->fmilib_handle() != nullptr);
+    BOOST_TEST(std::static_pointer_cast<fmi::v2::fmu>(fmu)->directory().filename() == "ad6d7bad-97d1-4fb9-ab3e-00a0d051e42c");
 
     auto instance = fmu->instantiate_slave("testSlave");
     instance->setup(


### PR DESCRIPTION
To avoid unzipping the fmus in a directory containing curly brackets, we simply suggest removing them.

