### PR TITLE
Bugfix/262 garbled modeldescription fmu proxy

### DIFF
--- a/src/cpp/cse/fmuproxy/fmuproxy_helper.hpp
+++ b/src/cpp/cse/fmuproxy/fmuproxy_helper.hpp
@@ -58,6 +58,8 @@ inline cse::variable_type get_type(const fmuproxy::thrift::ScalarVariable& v)
         return cse::variable_type::string;
     } else if (v.attribute.__isset.boolean_attribute) {
         return cse::variable_type::boolean;
+    } else if (v.attribute.__isset.enumeration_attribute) {
+        return cse::variable_type::enumeration;
     } else {
         const auto err = "Failed to get type of variable: '" + v.name + "'";
         CSE_PANIC_M(err.c_str());


### PR DESCRIPTION
Fix issue where the variable list retreived from fmu-proxy would contain a bunch of "empty/default" variable instances due to the use of a list with to large capacity.

Also assigns starts values, which was not the case before.

Resolves #262 