### PR TITLE
Print the name of the FMU in errormsg - canBeInstantiatedOnlyOncePerProcess

### DIFF
--- a/src/cpp/fmi/v1/fmu.cpp
+++ b/src/cpp/fmi/v1/fmu.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<v1::slave_instance> fmu::instantiate_v1_slave(
     if (isSingleton && !instances_.empty()) {
         throw error(
             make_error_code(errc::unsupported_feature),
-            "FMU can only be instantiated once");
+            "FMU '" + modelDescription_.name + "' can only be instantiated once");
     }
     auto instance = std::shared_ptr<slave_instance>(
         new slave_instance(shared_from_this(), instanceName));

--- a/src/cpp/fmi/v2/fmu.cpp
+++ b/src/cpp/fmi/v2/fmu.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<v2::slave_instance> fmu::instantiate_v2_slave(
     if (isSingleton && !instances_.empty()) {
         throw error(
             make_error_code(errc::unsupported_feature),
-            "FMU can only be instantiated once");
+            "FMU '" + modelDescription_.name + "' can only be instantiated once");
     }
     auto instance = std::shared_ptr<slave_instance>(
         new slave_instance(shared_from_this(), instanceName));


### PR DESCRIPTION
Improve error messages
Old output
```
Error: Unsupported feature: FMU can only be instantiated once
```
New output
```
Error: Unsupported feature: FMU 'nameoffmu' can only be instantiated once
```