### PR TITLE
Feature/make Jenkins great again

### DIFF
--- a/.dockerfiles/Dockerfile.build
+++ b/.dockerfiles/Dockerfile.build
@@ -8,6 +8,7 @@ RUN apt-get update && \
     cmake \
     doxygen \
     git \
+    flex \
     libboost-all-dev \
     libevent-dev \
     libzip-dev \

--- a/.dockerfiles/Dockerfile.conan-build
+++ b/.dockerfiles/Dockerfile.conan-build
@@ -7,6 +7,7 @@ RUN apt-get update && \
     build-essential \
     doxygen \
     git \
+    flex \
     python3-setuptools \
     python3-wheel \
     python3-pip \

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.swp
 build/
+debug-build/
+release-build/
 
 # JetBrains CLion:
 .idea/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,12 @@
 pipeline {
     agent none
 
+    environment {
+        CONAN_USER_HOME_SHORT = 'None'
+        OSP_CONAN_CREDS = credentials('jenkins-osp-conan-creds')
+        CSE_CONAN_CHANNEL = "${env.BRANCH_NAME}".replaceAll("/", "_")
+    }
+
     options { checkoutToSubdirectory('cse-core') }
 
     stages {
@@ -11,12 +17,9 @@ pipeline {
                     agent { label 'windows' }
                     
                     environment {
-                        CONAN_USER_HOME = "${env.BASE}\\conan-repositories\\${env.EXECUTOR_NUMBER}"
-                        CONAN_USER_HOME_SHORT = "${env.CONAN_USER_HOME}"
-                        OSP_CONAN_CREDS = credentials('jenkins-osp-conan-creds')
-                        CSE_CONAN_CHANNEL = "${env.BRANCH_NAME}".replaceAll("/", "_")
+                        CONAN_USER_HOME = "${env.SLAVE_HOME}/conan-repositories/${env.EXECUTOR_NUMBER}"
                     }
-
+                    
                     stages {
                         stage('Configure Conan') {
                             steps {
@@ -109,10 +112,7 @@ pipeline {
                     agent { label 'windows' }
 
                     environment {
-                        CONAN_USER_HOME = "${env.BASE}\\conan-repositories\\${env.EXECUTOR_NUMBER}"
-                        CONAN_USER_HOME_SHORT = "${env.CONAN_USER_HOME}"
-                        OSP_CONAN_CREDS = credentials('jenkins-osp-conan-creds')
-                        CSE_CONAN_CHANNEL = "${env.BRANCH_NAME}".replaceAll("/", "_")
+                        CONAN_USER_HOME = "${env.SLAVE_HOME}/conan-repositories/${env.EXECUTOR_NUMBER}"
                     }
 
                     stages {
@@ -120,6 +120,7 @@ pipeline {
                             steps {
                                 sh 'conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/conan-local --force'
                                 sh 'conan remote add helmesjo https://api.bintray.com/conan/helmesjo/public-conan --force'
+                                sh 'conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan --force'
                                 sh 'conan user -p $OSP_CONAN_CREDS_PSW -r osp $OSP_CONAN_CREDS_USR'
                             }
                         }
@@ -139,15 +140,12 @@ pipeline {
                             filename 'Dockerfile.conan-build'
                             dir 'cse-core/.dockerfiles'
                             label 'linux && docker'
-                            args '-v ${HOME}/jenkins_slave/conan-repositories/${EXECUTOR_NUMBER}:/conan_repo'
+                            args '-v ${SLAVE_HOME}/conan-repositories/${EXECUTOR_NUMBER}:/conan_repo'
                         }
                     }
 
                     environment {
                         CONAN_USER_HOME = '/conan_repo'
-                        CONAN_USER_HOME_SHORT = 'None'
-                        OSP_CONAN_CREDS = credentials('jenkins-osp-conan-creds')
-                        CSE_CONAN_CHANNEL = "${env.BRANCH_NAME}".replaceAll("/", "_")
                     }
                     
                     stages {
@@ -244,15 +242,12 @@ pipeline {
                             filename 'Dockerfile.conan-build'
                             dir 'cse-core/.dockerfiles'
                             label 'linux && docker'
-                            args '-v ${HOME}/jenkins_slave/conan-repositories/${EXECUTOR_NUMBER}:/conan_repo'
+                            args '-v ${SLAVE_HOME}/conan-repositories/${EXECUTOR_NUMBER}:/conan_repo'
                         }
                     }
 
                     environment {
                         CONAN_USER_HOME = '/conan_repo'
-                        CONAN_USER_HOME_SHORT = 'None'
-                        OSP_CONAN_CREDS = credentials('jenkins-osp-conan-creds')
-                        CSE_CONAN_CHANNEL = "${env.BRANCH_NAME}".replaceAll("/", "_")
                     }
 
                     stages {
@@ -260,6 +255,7 @@ pipeline {
                             steps {
                                 sh 'conan remote add osp https://osp-conan.azurewebsites.net/artifactory/api/conan/conan-local --force'
                                 sh 'conan remote add helmesjo https://api.bintray.com/conan/helmesjo/public-conan --force'
+                                sh 'conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan --force'
                                 sh 'conan user -p $OSP_CONAN_CREDS_PSW -r osp $OSP_CONAN_CREDS_USR'
                             }
                         }
@@ -294,7 +290,7 @@ pipeline {
                         }
                         stage('Build Release') {
                             steps {
-                                dir('release-build ') {
+                                dir('release-build') {
                                     sh 'cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install/linux/release -DCSECORE_USING_CONAN=FALSE -DCSECORE_BUILD_PRIVATE_APIDOC=ON ../cse-core'
                                     sh 'cmake --build .'
                                     sh 'cmake --build . --target install'


### PR DESCRIPTION
After moving the server hosting the Linux Jenkins slave, and having tropical temperatures in our new server room some files on the Jenkins slave was corrupt. Starting over with clean Conan repos also revealed some missing dependencies(required to build Thrift). This was masked by having pre-compiled packages available in the local repo. This PR fixes these problems, and enables build of Thrift as well.

I suggest that when approved and merged, we merge this PR into all existing branches on cse-core.