### PR TITLE
Bump version to 0.4.0 in CMakeLists.txt too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project("csecore" VERSION "0.3.0")
+project("csecore" VERSION "0.4.0")
 
 # ==============================================================================
 # Build settings


### PR DESCRIPTION
PR #297 only modified the version number in `conanfile.py`, and `find_package(csecore)` fails for CMake-based package consumers when these two are out of sync.