### PR TITLE
Force conan package upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                                 success {
                                     dir('debug-build') {
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/windows/debug --force"
-                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm"
+                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
                                     dir('debug-build/package') {
                                         archiveArtifacts artifacts: '**',  fingerprint: true
@@ -93,7 +93,7 @@ pipeline {
                                 success {
                                     dir('release-build') {
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/windows/release --force"
-                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm"
+                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
                                     dir('release-build/package') {
                                         archiveArtifacts artifacts: '**',  fingerprint: true
@@ -150,7 +150,7 @@ pipeline {
                                 success {
                                     dir('release-build-fmuproxy') {
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/windows/release --force"
-                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm"
+                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
                                     dir('release-build-fmuproxy/package') {
                                         archiveArtifacts artifacts: '**',  fingerprint: true
@@ -225,7 +225,7 @@ pipeline {
                                 success {
                                     dir('debug-build-conan') {
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/linux/debug --force"
-                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm"
+                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
                                     dir('debug-build-conan/package') {
                                         archiveArtifacts artifacts: '**',  fingerprint: true
@@ -256,7 +256,7 @@ pipeline {
                                 success {
                                     dir('release-build-conan') {
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/linux/release --force"
-                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm"
+                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
                                     dir('release-build-conan/package') {
                                         archiveArtifacts artifacts: '**',  fingerprint: true


### PR DESCRIPTION
This is a test where the result can only be determined after merging these changes to master. The criteria for success will be that the packages/binaries on our artifactory are properly updated.

The working hypothesis is that conan only uploads recipes. Using `--force` *should* ensure that both recipes and packages are uploaded.