### PR TITLE
Clean local conan cache before export-pkg

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
                                 }
                                 success {
                                     dir('debug-build') {
+                                        sh "conan remove cse-core --force"
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/windows/debug --force"
                                         sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
@@ -92,6 +93,7 @@ pipeline {
                                 }
                                 success {
                                     dir('release-build') {
+                                        sh "conan remove cse-core --force"
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/windows/release --force"
                                         sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
@@ -149,6 +151,7 @@ pipeline {
                                 }
                                 success {
                                     dir('release-build-fmuproxy') {
+                                        sh "conan remove cse-core --force"
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/windows/release --force"
                                         sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
@@ -224,6 +227,7 @@ pipeline {
                                 }
                                 success {
                                     dir('debug-build-conan') {
+                                        sh "conan remove cse-core --force"
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/linux/debug --force"
                                         sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
@@ -255,6 +259,7 @@ pipeline {
                                 }
                                 success {
                                     dir('release-build-conan') {
+                                        sh "conan remove cse-core --force"
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/linux/release --force"
                                         sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
@@ -319,8 +324,9 @@ pipeline {
                                 }
                                 success {
                                     dir('release-build-conan-fmuproxy') {
+                                        sh "conan remove cse-core --force"
                                         sh "conan export-pkg ../cse-core osp/${CSE_CONAN_CHANNEL} -pf package/linux/release --force"
-                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm"
+                                        sh "conan upload cse-core/*@osp/${CSE_CONAN_CHANNEL} --all -r=osp --confirm --force"
                                     }
                                     dir('release-build-conan-fmuproxy/package') {
                                         archiveArtifacts artifacts: '**',  fingerprint: true


### PR DESCRIPTION
This is the second attempt to fix the stale-packages-on-artifactory issue.

When we run `conan upload` at the end of each build stage, conan will upload all the packages it can find (for the branch we are building) in the local conan repo. If the current executor has previously built any *other* package for the same branch, then that package is also uploaded, resulting in outdated packages being pushed to artifactory. The proposed solution is to completely remove cse-core from the local conan repo before running `export-pkg` and `upload`. This should ensure that **only** the package currently being built is uploaded to artifactory. 

TLDR; Clean cache so conan uploads only the package produced by this build.