### PR TITLE
Make it possible to get cse-core through conan in debug mode without …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,9 +173,6 @@ if(DOXYGEN_FOUND)
         DEPENDS doc
     )
 else()
-    if (CSECORE_BUILD_PRIVATE_APIDOC)
-        message(FATAL_ERROR "Doxygen was not found, cannot build private API documentation!")
-    endif()
     message(WARNING "API documentation will not be built since Doxygen was not found.")
 endif()
 


### PR DESCRIPTION
…doxygen installed

Since the user is properly warned that doc will not be built anyway, I think we do not need to throw like we did. Right now conan users without doxygen cannot retrieve the debug target.

See #342 