### PR TITLE
Fix wrong use of std::isalnum()

### DIFF
--- a/src/cpp/uri.cpp
+++ b/src/cpp/uri.cpp
@@ -26,7 +26,8 @@ namespace
 
 bool is_scheme_char(char c) noexcept
 {
-    return std::isalnum(c) || c == '+' || c == '-' || c == '.';
+    return std::isalnum(static_cast<unsigned char>(c)) ||
+        c == '+' || c == '-' || c == '.';
 }
 
 std::optional<std::string_view> consume_scheme(std::string_view& input)


### PR DESCRIPTION
A `char` [should always](https://en.cppreference.com/w/cpp/string/byte/isalnum#Notes) be converted to an `unsigned char` before it is passed to one of the `<cctype>` functions, to ensure that its value is in the valid range (0–255). Looks like I forgot that here.