### PR TITLE
Support direct loading of ssp file

### DIFF
--- a/include/cse.h
+++ b/include/cse.h
@@ -143,7 +143,7 @@ cse_execution* cse_execution_create(
  *  Creates a new execution based on a SystemStructure.ssd file.
  *
  *  \param [in] sspDir
- *      Path to the directory holding SystemStructure.ssd
+ *      Path to an .ssd file, or a directory holding SystemStructure.ssd
  *  \param [in] startTimeDefined
  *      Defines whether or not the following startTime variable should be ignored or not.
  *  \param [in] startTime

--- a/include/cse/ssp_parser.hpp
+++ b/include/cse/ssp_parser.hpp
@@ -19,20 +19,37 @@ namespace cse
 
 using simulator_map = std::map<std::string, simulator_map_entry>;
 
+/**
+ *  Creates an execution based on a SystemStructure.ssd file.
+ *
+ *  \param [in] configPath
+ *      Path to an .ssd file, or a directory holding SystemStructure.ssd
+ *  \param [in] overrideStartTime
+ *      If defined, the (logical) time point at which the simulation should start.
+ *      If not defined, this variable will be read from .ssd file.
+ */
 std::pair<execution, simulator_map> load_ssp(
     cse::model_uri_resolver&,
-    const boost::filesystem::path& sspDir);
-
-std::pair<execution, simulator_map> load_ssp(
-    cse::model_uri_resolver&,
-    const boost::filesystem::path& sspDir,
+    const boost::filesystem::path& configPath,
     std::optional<cse::time_point> overrideStartTime);
 
-
+/**
+ *  Creates an execution based on a SystemStructure.ssd file.
+ *
+ *  \param [in] configPath
+ *      Path to an .ssd file, or a directory holding SystemStructure.ssd
+ *  \param [in] overrideAlgorithm
+ *      If defined, the co-simulation algorithm used in the execution.
+ *      If not defined, the algorithm will be a `fixed_step_algorithm` with
+ *      `stepSize` defined in the .ssd file.
+ *  \param [in] overrideStartTime
+ *      If defined, the (logical) time point at which the simulation should start.
+ *      If not defined, this variable will be read from the .ssd file.
+ */
 std::pair<execution, simulator_map> load_ssp(
     cse::model_uri_resolver&,
-    const boost::filesystem::path& sspDir,
-    std::shared_ptr<cse::algorithm> overrideAlgorithm,
+    const boost::filesystem::path& configPath,
+    std::shared_ptr<cse::algorithm> overrideAlgorithm = nullptr,
     std::optional<cse::time_point> overrideStartTime = std::nullopt);
 
 } // namespace cse

--- a/src/cpp/ssp_parser.cpp
+++ b/src/cpp/ssp_parser.cpp
@@ -294,29 +294,24 @@ cse::variable_id get_variable(
 
 std::pair<execution, simulator_map> load_ssp(
     cse::model_uri_resolver& resolver,
-    const boost::filesystem::path& sspDir)
-{
-    return load_ssp(resolver, sspDir, nullptr, std::nullopt);
-}
-
-std::pair<execution, simulator_map> load_ssp(
-    cse::model_uri_resolver& resolver,
-    const boost::filesystem::path& sspDir,
+    const boost::filesystem::path& configPath,
     std::optional<cse::time_point> overrideStartTime)
 {
-    return load_ssp(resolver, sspDir, nullptr, overrideStartTime);
+    return load_ssp(resolver, configPath, nullptr, overrideStartTime);
 }
 
 std::pair<execution, simulator_map> load_ssp(
     cse::model_uri_resolver& resolver,
-    const boost::filesystem::path& sspDir,
+    const boost::filesystem::path& configPath,
     std::shared_ptr<cse::algorithm> overrideAlgorithm,
     std::optional<cse::time_point> overrideStartTime)
 {
     simulator_map simulatorMap;
-    const auto ssdPath = boost::filesystem::absolute(sspDir) / "SystemStructure.ssd";
-    const auto baseURI = path_to_file_uri(ssdPath);
-    const auto parser = ssp_parser(ssdPath);
+    const auto configFile = boost::filesystem::is_regular_file(configPath)
+                            ? configPath
+                            : configPath / "SystemStructure.ssd";
+    const auto baseURI = path_to_file_uri(configFile);
+    const auto parser = ssp_parser(configFile);
 
     std::shared_ptr<cse::algorithm> algorithm;
     if (overrideAlgorithm != nullptr) {

--- a/test/cpp/ssp_parser_no_algorithm_elem_test.cpp
+++ b/test/cpp/ssp_parser_no_algorithm_elem_test.cpp
@@ -19,7 +19,7 @@ int main()
 
         const auto testDataDir = std::getenv("TEST_DATA_DIR");
         REQUIRE(testDataDir);
-        boost::filesystem::path xmlPath = boost::filesystem::path(testDataDir) / "ssp" / "demo" / "no_algorithm_element";
+        boost::filesystem::path xmlPath = boost::filesystem::path(testDataDir) / "ssp" / "demo" / "no_algorithm_element" / "SystemStructure.ssd";
 
         auto resolver = cse::default_model_uri_resolver();
         auto simulation = cse::load_ssp(


### PR DESCRIPTION
Closes #390, allowing client code to specify an .ssd file in addition to a directory containing one.

Also closes #308, documenting of `ssp_parser.hpp`.

Also removed unused overload of `load_ssp()`.