### PR TITLE
Thread safety for multiple step size simulators

### DIFF
--- a/src/cpp/algorithm.cpp
+++ b/src/cpp/algorithm.cpp
@@ -110,12 +110,10 @@ public:
             }
         }
 
-        ++stepCounter_;
-
-        std::unordered_set<simulator_index> finished;
         bool failed = false;
         std::stringstream errMessages;
-        for (auto& [idx, info] : simulators_) {
+        for (auto& s : simulators_) {
+            auto& info = s.second;
             if (stepCounter_ % info.decimationFactor == 0) {
                 if (auto ep = info.stepResult.get_exception_ptr()) {
                     errMessages
@@ -128,11 +126,20 @@ public:
                         << "Step not complete" << '\n';
                     failed = true;
                 }
-                finished.insert(idx);
             }
         }
+
         if (failed) {
             throw error(make_error_code(errc::simulation_error), errMessages.str());
+        }
+
+        ++stepCounter_;
+
+        std::unordered_set<simulator_index> finished;
+        for (auto& [idx, info] : simulators_) {
+            if (stepCounter_ % info.decimationFactor == 0) {
+                finished.insert(idx);
+            }
         }
 
         for (auto idx : finished) {

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
     "observer_multiple_slaves_test"
     "real_time_test"
     "connections_test"
+    "execution_from_cse_config_test"
     "execution_from_ssp_test"
     "execution_from_ssp_custom_algo_test"
     "time_series_observer_test"

--- a/test/c/execution_from_cse_config_test.c
+++ b/test/c/execution_from_cse_config_test.c
@@ -1,0 +1,93 @@
+#include <cse.h>
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WINDOWS
+#    include <windows.h>
+#else
+#    include <unistd.h>
+#    define Sleep(x) usleep((x)*1000)
+#endif
+
+void print_last_error()
+{
+    fprintf(
+        stderr,
+        "Error code %d: %s\n",
+        cse_last_error_code(), cse_last_error_message());
+}
+
+int main()
+{
+    cse_log_setup_simple_console_logging();
+    cse_log_set_output_level(CSE_LOG_SEVERITY_INFO);
+
+    int exitCode = 0;
+    cse_execution* execution = NULL;
+    cse_observer* observer = NULL;
+
+    const char* dataDir = getenv("TEST_DATA_DIR");
+    if (!dataDir) {
+        fprintf(stderr, "Environment variable TEST_DATA_DIR not set\n");
+        goto Lfailure;
+    }
+
+    char msmiDir[1024];
+    int rc = snprintf(msmiDir, sizeof msmiDir, "%s/msmi", dataDir);
+    if (rc < 0) {
+        perror(NULL);
+        goto Lfailure;
+    }
+
+    execution = cse_config_execution_create(msmiDir, false, 0);
+    if (!execution) { goto Lerror; }
+
+    observer = cse_last_value_observer_create();
+    if (!observer) { goto Lerror; }
+    cse_execution_add_observer(execution, observer);
+
+    rc = cse_execution_step(execution, 3);
+    if (rc < 0) { goto Lerror; }
+
+    size_t numSlaves = cse_execution_get_num_slaves(execution);
+
+    cse_slave_info infos[2];
+    rc = cse_execution_get_slave_infos(execution, &infos[0], numSlaves);
+    if (rc < 0) { goto Lerror; }
+
+    for (size_t i = 0; i < numSlaves; i++) {
+        if (0 == strncmp(infos[i].name, "KnuckleBoomCrane", SLAVE_NAME_MAX_SIZE)) {
+            double value = -1;
+            cse_slave_index slaveIndex = infos[i].index;
+            cse_value_reference varIndex = 2;
+            rc = cse_observer_slave_get_real(observer, slaveIndex, &varIndex, 1, &value);
+            if (rc < 0) {
+                goto Lerror;
+            }
+            if (value != 0.05) {
+                fprintf(stderr, "Expected value 0.05, got %f\n", value);
+                goto Lfailure;
+            }
+        }
+    }
+
+    cse_execution_start(execution);
+    Sleep(100);
+    cse_execution_stop(execution);
+
+    goto Lcleanup;
+
+Lerror:
+    print_last_error();
+
+Lfailure:
+    exitCode = 1;
+
+Lcleanup:
+    cse_observer_destroy(observer);
+    cse_execution_destroy(execution);
+    return exitCode;
+}


### PR DESCRIPTION
Quick and dirty proposal for #398. 

This changes the algorithm's behavior, in that when calling `simulator::do_step()`, the step result is collected in the same call of `algorithm::do_step()`. 

The proposed changes are slightly controversial, as a degree of parallelization is reduced. The benefit is that we no longer have any dangling running fibers, and the use of multiple step sizes becomes quite a bit safer.