### PR TITLE
Move visitor to utility header

### DIFF
--- a/src/cpp/async_slave.cpp
+++ b/src/cpp/async_slave.cpp
@@ -3,6 +3,7 @@
 #include "cse/error.hpp"
 #include "cse/exception.hpp"
 #include "cse/utility/concurrency.hpp"
+#include "cse/utility/utility.hpp"
 
 #include <boost/container/vector.hpp>
 #include <boost/fiber/fixedsize_stack.hpp>
@@ -452,23 +453,6 @@ T get_reply(reply_channel& replyChannel)
         CSE_PANIC_M("Unexpected reply type");
     }
 }
-
-/*
- *  A generic visitor that can be constructed on the fly from a set of lambdas.
- *
- *  Inspired by:
- *  https://arne-mertz.de/2018/05/overload-build-a-variant-visitor-on-the-fly/
- */
-template<typename... Functors>
-struct visitor : Functors...
-{
-    visitor(const Functors&... functors)
-        : Functors(functors)...
-    {
-    }
-
-    using Functors::operator()...;
-};
 
 // An exception which signals normal shutdown of the background thread.
 struct shutdown_background_thread

--- a/src/cpp/cse/utility/utility.hpp
+++ b/src/cpp/cse/utility/utility.hpp
@@ -1,0 +1,28 @@
+#ifndef CSE_UTILITY_UTILITY_HPP
+#define CSE_UTILITY_UTILITY_HPP
+
+
+namespace cse
+{
+
+
+/**
+ *  A generic visitor that can be constructed on the fly from a set of lambdas.
+ *
+ *  Inspired by:
+ *  https://arne-mertz.de/2018/05/overload-build-a-variant-visitor-on-the-fly/
+ */
+template<typename... Functors>
+struct visitor : Functors...
+{
+    visitor(const Functors&... functors)
+        : Functors(functors)...
+    {
+    }
+
+    using Functors::operator()...;
+};
+
+
+} // namespace cse
+#endif // header guard

--- a/src/cpp/manipulator/override_manipulator.cpp
+++ b/src/cpp/manipulator/override_manipulator.cpp
@@ -1,6 +1,6 @@
-
-#include <cse/manipulator.hpp>
-#include <cse/error.hpp>
+#include "cse/error.hpp"
+#include "cse/manipulator.hpp"
+#include "cse/utility/utility.hpp"
 
 #include <sstream>
 
@@ -9,17 +9,6 @@ namespace cse
 
 namespace
 {
-
-template<typename... Functors>
-struct visitor : Functors...
-{
-    visitor(const Functors&... functors)
-        : Functors(functors)...
-    {
-    }
-
-    using Functors::operator()...;
-};
 
 cse::variable_causality find_variable_causality(
     const std::vector<variable_description>& variables,

--- a/src/cpp/manipulator/scenario_manager.cpp
+++ b/src/cpp/manipulator/scenario_manager.cpp
@@ -4,25 +4,10 @@
 #include "cse/log/logger.hpp"
 #include "cse/scenario.hpp"
 #include "cse/scenario_parser.hpp"
+#include "cse/utility/utility.hpp"
 
 namespace cse
 {
-
-namespace
-{
-
-template<typename... Functors>
-struct visitor : Functors...
-{
-    visitor(const Functors&... functors)
-        : Functors(functors)...
-    {
-    }
-
-    using Functors::operator()...;
-};
-
-} // namespace
 
 class scenario_manager::impl
 {


### PR DESCRIPTION
The `visitor` class was already in violation of the Rule of three, and I'm soon going to need it in a fourth place, so I figured it's time to move it to a header.