### PR TITLE
Add get_simulator_index to execution

### DIFF
--- a/include/cse/execution.hpp
+++ b/include/cse/execution.hpp
@@ -245,7 +245,7 @@ public:
     /// Set initial value for a variable of type string. Must be called before simulation is started.
     void set_string_initial_value(simulator_index sim, value_reference var, const std::string& value);
 
-    simulator_index get_index(const std::string& name);
+    simulator_index get_simulator_index(const std::string& name);
 
 private:
     class impl;

--- a/src/cpp/execution.cpp
+++ b/src/cpp/execution.cpp
@@ -271,8 +271,8 @@ public:
         simulators_.at(sim)->set_string(var, value);
     }
 
-    simulator_index get_index(const std::string& name) {
-        int index = 0;
+    simulator_index get_simulator_index(const std::string& name) {
+        auto index = 0;
         for (const auto& sim : simulators_) {
             if (sim->name() == name) {
                 return index;
@@ -457,9 +457,9 @@ void execution::set_string_initial_value(simulator_index sim, value_reference va
     pimpl_->set_string_initial_value(sim, var, value);
 }
 
-simulator_index execution::get_index(const std::string& name)
+simulator_index execution::get_simulator_index(const std::string& name)
 {
-    return pimpl_->get_index(name);
+    return pimpl_->get_simulator_index(name);
 }
 
 } // namespace cse


### PR DESCRIPTION
Allow retrieving the `simulation_index` using a `simulator` name.
This is simply just a useful function to have.

The implementation and function name in this PR must be rewritten once we decide to go forward with #384, but lets just add this to our API now.