### PR TITLE
Make sure empty folders are created during extraction.

### DIFF
--- a/src/cpp/utility/zip.cpp
+++ b/src/cpp/utility/zip.cpp
@@ -255,6 +255,7 @@ void archive::extract_all(
             if (entryName.back() == '/') {
                 boost::filesystem::create_directories(targetPath);
             } else {
+                boost::filesystem::create_directories(targetPath.parent_path());
                 extract_file_as(m_archive, index, targetPath, buffer);
             }
         }


### PR DESCRIPTION
This should fix #440 by also creating empty directories during extraction of FMU as some FMUs expects these directories to exist.