### PR TITLE
Make step size an execution-local subsimulator property

### DIFF
--- a/include/cse/algorithm/algorithm.hpp
+++ b/include/cse/algorithm/algorithm.hpp
@@ -43,8 +43,16 @@ public:
      *      A pointer to an object that is used to control the simulator.
      *      Note that the algorithm does not have resource ownership of
      *      the object it points to (i.e., should not try to delete it).
+     *  \param stepSizeHint
+     *      The recommended co-simulation step size for this simulator.
+     *      The algorithm is free to choose whether and how this is taken
+     *      into account.  The algorithm is also responsible for selecting
+     *      a sensible default if this is zero.
      */
-    virtual void add_simulator(simulator_index index, simulator* sim) = 0;
+    virtual void add_simulator(
+        simulator_index index,
+        simulator* sim,
+        duration stepSizeHint) = 0;
 
     /**
      *  Removes a simulator from the co-simulation.

--- a/include/cse/algorithm/fixed_step_algorithm.hpp
+++ b/include/cse/algorithm/fixed_step_algorithm.hpp
@@ -33,7 +33,7 @@ public:
     fixed_step_algorithm& operator=(fixed_step_algorithm&&) noexcept;
 
     // `algorithm` methods
-    void add_simulator(simulator_index i, simulator* s) override;
+    void add_simulator(simulator_index i, simulator* s, duration stepSizeHint) override;
     void remove_simulator(simulator_index i) override;
     void add_connection(std::shared_ptr<connection> c) override;
     void remove_connection(std::shared_ptr<connection> c) override;

--- a/include/cse/execution.hpp
+++ b/include/cse/execution.hpp
@@ -126,10 +126,15 @@ public:
      *      An object that provides asynchronous communication with the slave.
      *  \param name
      *      An execution-specific name for the slave.
+     *  \param stepSizeHint
+     *      The recommended co-simulation step size for this slave.
+     *      Whether and how this is taken into account is algorithm dependent.
+     *      If zero, the algorithm will attempt to choose a sensible default.
      */
     simulator_index add_slave(
         std::shared_ptr<async_slave> slave,
-        std::string_view name);
+        std::string_view name,
+        duration stepSizeHint = duration::zero());
 
     /// Adds an observer to the execution.
     void add_observer(std::shared_ptr<observer> obs);

--- a/src/cpp/algorithm/fixed_step_algorithm.cpp
+++ b/src/cpp/algorithm/fixed_step_algorithm.cpp
@@ -2,17 +2,23 @@
 
 #include "cse/error.hpp"
 #include "cse/exception.hpp"
+#include "cse/log/logger.hpp"
 
 #include <gsl/span>
 
 #include <algorithm>
+#include <cstdlib>
 #include <numeric>
 #include <sstream>
 #include <unordered_map>
 #include <vector>
 
+
+namespace cse
+{
 namespace
 {
+
 std::string exception_ptr_msg(std::exception_ptr ep)
 {
     assert(ep);
@@ -24,11 +30,28 @@ std::string exception_ptr_msg(std::exception_ptr ep)
         return "Unknown error";
     }
 }
+
+int calculate_decimation_factor(
+    std::string_view name,
+    duration baseStepSize,
+    duration simulatorStepSize)
+{
+    const auto result = std::div(simulatorStepSize.count(), baseStepSize.count());
+    const int factor = std::max<int>(1, static_cast<int>(result.quot));
+    if (result.rem > 0 || result.quot < 1) {
+        duration actualStepSize = baseStepSize * factor;
+        const auto startTime = time_point();
+        BOOST_LOG_SEV(log::logger(), log::warning)
+            << "Effective step size for " << name
+            << " will be " << to_double_duration(actualStepSize, startTime) << " s"
+            << " instead of configured value "
+            << to_double_duration(simulatorStepSize, startTime) << " s";
+    }
+    return factor;
+}
+
 } // namespace
 
-
-namespace cse
-{
 
 class fixed_step_algorithm::impl
 {
@@ -47,10 +70,12 @@ public:
     impl(impl&&) = delete;
     impl& operator=(impl&&) = delete;
 
-    void add_simulator(simulator_index i, simulator* s)
+    void add_simulator(simulator_index i, simulator* s, duration stepSizeHint)
     {
         assert(simulators_.count(i) == 0);
         simulators_[i].sim = s;
+        simulators_[i].decimationFactor =
+            calculate_decimation_factor(s->name(), baseStepSize_, stepSizeHint);
     }
 
     void remove_simulator(simulator_index i)
@@ -330,9 +355,10 @@ fixed_step_algorithm& fixed_step_algorithm::operator=(
 
 void fixed_step_algorithm::add_simulator(
     simulator_index i,
-    simulator* s)
+    simulator* s,
+    duration stepSizeHint)
 {
-    pimpl_->add_simulator(i, s);
+    pimpl_->add_simulator(i, s, stepSizeHint);
 }
 
 

--- a/src/cpp/execution.cpp
+++ b/src/cpp/execution.cpp
@@ -39,11 +39,12 @@ public:
 
     simulator_index add_slave(
         std::shared_ptr<async_slave> slave,
-        std::string_view name)
+        std::string_view name,
+        duration stepSizeHint)
     {
         const auto index = static_cast<simulator_index>(simulators_.size());
         simulators_.push_back(std::make_unique<slave_simulator>(slave, name));
-        algorithm_->add_simulator(index, simulators_.back().get());
+        algorithm_->add_simulator(index, simulators_.back().get(), stepSizeHint);
 
         for (const auto& obs : observers_) {
             obs->simulator_added(index, simulators_.back().get(), currentTime_);
@@ -336,9 +337,10 @@ execution& execution::operator=(execution&& other) noexcept = default;
 
 simulator_index execution::add_slave(
     std::shared_ptr<async_slave> slave,
-    std::string_view name)
+    std::string_view name,
+    duration stepSizeHint)
 {
-    return pimpl_->add_slave(std::move(slave), name);
+    return pimpl_->add_slave(std::move(slave), name, stepSizeHint);
 }
 
 void execution::add_observer(std::shared_ptr<observer> obs)


### PR DESCRIPTION
Since my suggestion in #453 seemed to resonate with people, and this was actually pretty simple to implement, I just went ahead and did it.

Closes #453, once we agree that that question is settled.

This does not take into account the FMI 2.0 `DefaultExperiment.stepSize` attribute due to modelon-community/fmi-library#4. We'll just have to deal with that later, if they fix their bug.