### PR TITLE
Use official thrift remote

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class CSECoreConan(ConanFile):
 
     def requirements(self):
         if self.options.fmuproxy:
-            self.requires("thrift/0.12.0@osp/testing")
+            self.requires("thrift/0.12.0@bincrafters/stable")
 
     def configure_cmake(self):
         cmake = CMake(self)


### PR DESCRIPTION
There was some issues with the remote in the past, but it is fixed now:

```python
def requirements(self):
        self.requires("boost/1.69.0@conan/stable")
        if self.settings.os == 'Windows':
            self.requires("winflexbison/2.5.18@bincrafters/stable")
        else:
            self.requires("flex/2.6.4@bincrafters/stable")
            self.requires("bison/3.0.5@bincrafters/stable")

        if self.options.with_openssl:
            self.requires("openssl/1.0.2t")
        if self.options.with_zlib:
            self.requires("zlib/1.2.11")
        if self.options.with_libevent:
            self.requires("libevent/2.1.11")
```

This PR is required to fix breakage of conan. `Unable to find 'thrift/0.12.0@osp/testing' in remotes`