### PR TITLE
Findyaml-cpp.cmake was not added to the install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,7 @@ install(FILES
         "${CMAKE_SOURCE_DIR}/cmake/FindLIBZIP.cmake"
         "${CMAKE_SOURCE_DIR}/cmake/FindMS_GSL.cmake"
         "${CMAKE_SOURCE_DIR}/cmake/FindTHRIFT.cmake"
+        "${CMAKE_SOURCE_DIR}/cmake/Findyaml-cpp.cmake"
         DESTINATION
         "${CSECORE_CMAKE_INSTALL_DIR}"
 )


### PR DESCRIPTION
This is required for clients that uses `conan` to fetch `cse-core` in order to find `yaml-cpp` as long as we need to use a custom find script.