### PR TITLE
Re-enable parallel builds under Conan

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,6 @@ class CSECoreConan(ConanFile):
 
     def configure_cmake(self):
         cmake = CMake(self)
-        cmake.parallel = False # Needed to keep stable build on Jenkins Windows Node
         cmake.definitions["CSECORE_USING_CONAN"] = "ON"
         if self.settings.build_type == "Debug":
             cmake.definitions["CSECORE_BUILD_PRIVATE_APIDOC"] = "ON"


### PR DESCRIPTION
Parallel builds were disabled in `conanfile.py` at some point because they proved troublesome on the Windows Jenkins nodes.  Since then, the compiler has been updated several times, so parallel builds may be a possibility again.