### PR TITLE
Revert "Set scm.url="auto" in conanfile.py (#503)"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class CSECoreConan(ConanFile):
     exports = "version.txt"
     scm = {
         "type": "git",
-        "url": "auto",
+        "url": "git@github.com:open-simulation-platform/cse-core.git",
         "revision": "auto"
     }
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
This reverts PR #503.

It caused a problem in the case where the recipe is downloaded from Artifactory, but the package is built locally (e.g. with `conan install --build=<package>`).

The reason is that `auto` gets replaced with a HTTPS repository address, because that's what Jenkins uses, but most people/systems don't have the proper credentials for that set up. I don't know if it is possible or worth it to switch to SSH repo addresses on Jenkins, but until that is established, lets revert the change and reopen issue #502.