### PR TITLE
Always check out version.txt with EOL=LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Declare files that will always have LF line endings on checkout.
 conanfile.py text eol=lf
+version.txt text eol=lf


### PR DESCRIPTION
This is to ensure that Conan generates the same package revision hashes on different platforms.