### PR TITLE
xml and xsd versioning

### DIFF
--- a/src/cpp/xsd/OspSystemStructure.xsd
+++ b/src/cpp/xsd/OspSystemStructure.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
            targetNamespace="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
-           xmlns:osp="http://opensimulationplatform.com/MSMI/OSPSystemStructure">
+           xmlns:osp="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
+           version="0.1">
     <xs:element name="OspSystemStructure">
         <xs:complexType>
             <xs:sequence>
@@ -12,6 +13,11 @@
                 <xs:element name="Functions" type="osp:functions" minOccurs="0"/>
                 <xs:element name="Connections" type="osp:connections" minOccurs="0"/>
             </xs:sequence>
+            <xs:attribute name="version" type="xs:normalizedString" use="required" fixed="0.1">
+                <xs:annotation>
+                    <xs:documentation>Version of CSE configuration format</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="connections">

--- a/test/data/msmi/OspSystemStructure.xml
+++ b/test/data/msmi/OspSystemStructure.xml
@@ -2,7 +2,8 @@
 <OspSystemStructure
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://opensimulationplatform.com/MSMI/OSPSystemStructure ../../../src/cpp/xsd/OspSystemStructure.xsd"
-        xmlns="http://opensimulationplatform.com/MSMI/OSPSystemStructure">
+        xmlns="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
+        version="0.1">
     <StartTime>0.0</StartTime>
     <BaseStepSize>1e-4</BaseStepSize>
     <Algorithm>fixedStep</Algorithm>

--- a/test/data/msmi/OspSystemStructure_Bond.xml
+++ b/test/data/msmi/OspSystemStructure_Bond.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<OspSystemStructure xmlns="http://opensimulationplatform.com/MSMI/OSPSystemStructure">
+<OspSystemStructure
+        xmlns="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
+        version="0.1">
     <StartTime>0.0</StartTime>
     <BaseStepSize>1e-4</BaseStepSize>
     <Algorithm>fixedStep</Algorithm>

--- a/test/data/msmi/OspSystemStructure_vectorSum.xml
+++ b/test/data/msmi/OspSystemStructure_vectorSum.xml
@@ -2,7 +2,8 @@
 <OspSystemStructure
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://opensimulationplatform.com/MSMI/OSPSystemStructure ../../../src/cpp/xsd/OspSystemStructure.xsd"
-        xmlns="http://opensimulationplatform.com/MSMI/OSPSystemStructure">
+        xmlns="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
+        version="0.1">
     <StartTime>0.0</StartTime>
     <BaseStepSize>1e-1</BaseStepSize>
     <Algorithm>fixedStep</Algorithm>

--- a/test/data/msmi/schema/OspModelDescription.xsd
+++ b/test/data/msmi/schema/OspModelDescription.xsd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
            targetNamespace="http://opensimulationplatform.com/MSMI/OSPModelDescription"
-           xmlns:osp="http://opensimulationplatform.com/MSMI/OSPModelDescription">
+           xmlns:osp="http://opensimulationplatform.com/MSMI/OSPModelDescription"
+           version="0.1">
     <xs:include schemaLocation="fmi2Unit.xsd"/>
     <xs:element name="OspModelDescription">
         <xs:complexType>
@@ -15,6 +16,11 @@
                 </xs:element>
                 <xs:element name="VariableGroups" type="osp:variablegroups"/>
             </xs:sequence>
+            <xs:attribute name="msmiVersion" type="xs:normalizedString" use="required" fixed="0.1">
+                <xs:annotation>
+                    <xs:documentation>MSMI version</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:complexType name="variablegroups">


### PR DESCRIPTION
- Suggesting msmiVersion tag to root element in OspModelDescription.xml as this format will be related to MSMI.
- Added version tag to root element in OspSystemStructure.xml
- Setting the version attribute in the xsds

Closes #411 
