### PR TITLE
Exclude generated Thrift files from documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ if(DOXYGEN_FOUND)
     set(DOXYGEN_JAVADOC_AUTOBRIEF "YES")
     set(DOXYGEN_QT_AUTOBRIEF "YES")
     set(DOXYGEN_MULTILINE_CPP_IS_BRIEF "YES")
-    set(DOXYGEN_EXCLUDE_PATTERNS "*.cpp" "*.c")
+    set(DOXYGEN_EXCLUDE_PATTERNS "*.cpp" "*.c" "*/fmuproxy/*service*")
     set(doxygenInputs "${CMAKE_SOURCE_DIR}/include")
     if(CSECORE_BUILD_PRIVATE_APIDOC)
         list(APPEND doxygenInputs


### PR DESCRIPTION
This speeds up doc generation enormously and greatly reduces the number of warnings printed by Doxygen. The files contain no doc comments anyway, so it makes no difference on the output.