### PR TITLE
Fix mock_slave and lots of magic numbers

### DIFF
--- a/test/cpp/async_slave_mockup_test.cpp
+++ b/test/cpp/async_slave_mockup_test.cpp
@@ -74,9 +74,8 @@ void run_test(std::shared_ptr<cse::async_slave> (*make_async)(std::shared_ptr<cs
         // slave's sole real output variable.
         std::vector<future<cse::async_slave::variable_values>> getResults;
         for (const auto& slave : asyncSlaves) {
-            const cse::value_reference realOutIndex = 0;
             getResults.push_back(
-                slave->get_variables({&realOutIndex, 1}, {}, {}, {}));
+                slave->get_variables({&mock_slave::real_out_reference, 1}, {}, {}, {}));
         }
         std::vector<double> values; // To be filled with one value per slave
         for (auto& r : getResults) {
@@ -90,10 +89,9 @@ void run_test(std::shared_ptr<cse::async_slave> (*make_async)(std::shared_ptr<cs
 
         std::vector<future<void>> setResults;
         for (int i = 0; i < numSlaves; ++i) {
-            const cse::value_reference realInIndex = 1;
             setResults.push_back(
                 asyncSlaves[i]->set_variables(
-                    {&realInIndex, 1}, {&values[i], 1},
+                    {&mock_slave::real_in_reference, 1}, {&values[i], 1},
                     {}, {},
                     {}, {},
                     {}, {}));

--- a/test/cpp/fixed_step_algorithm_test.cpp
+++ b/test/cpp/fixed_step_algorithm_test.cpp
@@ -27,7 +27,7 @@ int main()
         constexpr cse::time_point startTime;
         constexpr cse::time_point midTime = cse::to_time_point(0.6);
         constexpr cse::time_point endTime = cse::to_time_point(1.0);
-        constexpr cse::duration stepSize = cse::to_duration(0.1);
+        constexpr cse::duration stepSize = cse::to_duration(0.05);
 
         // Set up execution
         auto execution = cse::execution(
@@ -40,26 +40,38 @@ int main()
         auto observer = std::make_shared<cse::last_value_observer>();
         execution.add_observer(observer);
 
-        const cse::value_reference realOutRef = 0;
-        const cse::value_reference realInRef = 1;
+        const cse::value_reference realOutRef = mock_slave::real_out_reference;
+        const cse::value_reference realInRef = mock_slave::real_in_reference;
 
 
         // Add slaves to it
-        for (int i = 0; i < numSlaves; ++i) {
+        std::vector<cse::simulator_index> slaves;
+        slaves.push_back(
             execution.add_slave(
-                cse::make_pseudo_async(std::make_unique<mock_slave>([](double x) { return x + 1.234; })),
-                "slave" + std::to_string(i));
-            if (i > 0) {
-                execution.add_connection(
-                    std::make_shared<cse::scalar_connection>(
-                        cse::variable_id{i - 1, cse::variable_type::real, realOutRef},
-                        cse::variable_id{i, cse::variable_type::real, realInRef}));
-            }
+                cse::make_pseudo_async(
+                    std::make_unique<mock_slave>([](cse::time_point t, double) {
+                        return cse::to_double_time_point(t);
+                    })),
+                "clock_slave"));
+        for (int i = 1; i < numSlaves; ++i) {
+            slaves.push_back(
+                execution.add_slave(
+                    cse::make_pseudo_async(
+                        std::make_unique<mock_slave>([](double x) {
+                            return x + 1.234;
+                    })),
+                    "adder_slave" + std::to_string(i)));
+            execution.add_connection(
+                std::make_shared<cse::scalar_connection>(
+                    cse::variable_id{slaves[i - 1], cse::variable_type::real, realOutRef},
+                    cse::variable_id{slaves[i], cse::variable_type::real, realInRef}));
         }
 
+        // Add an observer that watches the last slave
         auto observer2 = std::make_shared<cse::time_series_observer>();
         execution.add_observer(observer2);
-        observer2->start_observing(cse::variable_id{9, cse::variable_type::real, realOutRef});
+        observer2->start_observing(
+            cse::variable_id{slaves.back(), cse::variable_type::real, realOutRef});
 
         // Run simulation
         auto simResult = execution.simulate_until(midTime);
@@ -70,40 +82,26 @@ int main()
         simResult = execution.simulate_until(endTime);
         REQUIRE(simResult.get());
 
-
-        double realOutValue = -1.0;
-        double realInValue = -1.0;
-
-        for (int j = 0; j < numSlaves; j++) {
-            double lastRealOutValue = realOutValue;
-            observer->get_real(j, gsl::make_span(&realOutRef, 1), gsl::make_span(&realOutValue, 1));
-            observer->get_real(j, gsl::make_span(&realInRef, 1), gsl::make_span(&realInValue, 1));
-            if (j > 0) {
-                // Check that real input of slave j has same value as real output of slave j - 1
-                REQUIRE(std::fabs(realInValue - lastRealOutValue) < 1.0e-9);
-            }
-        }
-
+        // Check that time, step number and output values increase monotonically
         const int numSamples = 10;
         double realValues[numSamples];
         cse::step_number steps[numSamples];
         cse::time_point timeValues[numSamples];
-        observer2->get_real_samples(9, realOutRef, 1, gsl::make_span(realValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(timeValues, numSamples));
-        cse::step_number lastStep = -1;
-        double lastValue = -1.0;
-        for (int k = 0; k < numSamples; k++) {
-            REQUIRE(steps[k] > lastStep);
-            lastStep = steps[k];
+        observer2->get_real_samples(
+            slaves.back(),
+            realOutRef,
+            numSlaves, // changes won't propagate to the last slave until the numSlaves'th step
+            gsl::make_span(realValues, numSamples),
+            gsl::make_span(steps, numSamples),
+            gsl::make_span(timeValues, numSamples));
 
-            REQUIRE(realValues[k] > lastValue);
-            lastValue = realValues[k];
-
-            if (k > 0) {
-                cse::duration diff = timeValues[k] - timeValues[k - 1];
-                REQUIRE(diff == stepSize);
-            }
+        for (int k = 1; k < numSamples; k++) {
+            REQUIRE(steps[k] > steps[k-1]);
+            REQUIRE(realValues[k] > realValues[k-1]);
+            REQUIRE(timeValues[k] - timeValues[k-1] == stepSize);
         }
 
+        // Run for another period with an RTF target > 1
         constexpr auto finalTime = cse::to_time_point(2.0);
         constexpr double rtfTarget = 2.25;
         execution.enable_real_time_simulation();

--- a/test/cpp/last_value_observer_test.cpp
+++ b/test/cpp/last_value_observer_test.cpp
@@ -45,64 +45,70 @@ int main()
 
         execution.step();
 
-        const cse::value_reference outIndex = 0;
-        const cse::value_reference inIndex = 1;
+        const cse::value_reference realOutRef = mock_slave::real_out_reference;
+        const cse::value_reference realInRef  = mock_slave::real_in_reference;
+        const cse::value_reference intOutRef = mock_slave::integer_out_reference;
+        const cse::value_reference intInRef  = mock_slave::integer_in_reference;
+        const cse::value_reference boolOutRef = mock_slave::boolean_out_reference;
+        const cse::value_reference boolInRef  = mock_slave::boolean_in_reference;
+        const cse::value_reference stringOutRef = mock_slave::string_out_reference;
+        const cse::value_reference stringInRef  = mock_slave::string_in_reference;
 
         double realInValue = -1.0;
         double realOutValue = -1.0;
-        observer->get_real(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&realInValue, 1));
-        observer->get_real(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&realOutValue, 1));
+        observer->get_real(sim, gsl::make_span(&realInRef, 1), gsl::make_span(&realInValue, 1));
+        observer->get_real(sim, gsl::make_span(&realOutRef, 1), gsl::make_span(&realOutValue, 1));
         REQUIRE(std::fabs(realInValue - 0.0) < 1.0e-9);
         REQUIRE(std::fabs(realOutValue - 1.234) < 1.0e-9);
 
         int intInValue = -1;
         int intOutValue = -1;
-        observer->get_integer(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&intInValue, 1));
-        observer->get_integer(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&intOutValue, 1));
+        observer->get_integer(sim, gsl::make_span(&intInRef, 1), gsl::make_span(&intInValue, 1));
+        observer->get_integer(sim, gsl::make_span(&intOutRef, 1), gsl::make_span(&intOutValue, 1));
         REQUIRE(intInValue == 0);
         REQUIRE(intOutValue == 1);
 
-        bool boolInValue = false;
-        bool boolOutValue = true;
-        observer->get_boolean(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&boolInValue, 1));
-        observer->get_boolean(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&boolOutValue, 1));
-        REQUIRE(boolInValue == true);
-        REQUIRE(boolOutValue == false);
+        bool boolInValue = true;
+        bool boolOutValue = false;
+        observer->get_boolean(sim, gsl::make_span(&boolInRef, 1), gsl::make_span(&boolInValue, 1));
+        observer->get_boolean(sim, gsl::make_span(&boolOutRef, 1), gsl::make_span(&boolOutValue, 1));
+        REQUIRE(boolInValue == false);
+        REQUIRE(boolOutValue == true);
 
         std::string stringInValue;
         std::string stringOutValue;
-        observer->get_string(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&stringInValue, 1));
-        observer->get_string(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&stringOutValue, 1));
+        observer->get_string(sim, gsl::make_span(&stringInRef, 1), gsl::make_span(&stringInValue, 1));
+        observer->get_string(sim, gsl::make_span(&stringOutRef, 1), gsl::make_span(&stringOutValue, 1));
         REQUIRE(stringInValue == "");
         REQUIRE(stringOutValue == "bar");
 
         auto manipulator = std::make_shared<cse::override_manipulator>();
         execution.add_manipulator(manipulator);
 
-        manipulator->override_real_variable(sim, inIndex, 2.0);
-        manipulator->override_integer_variable(sim, inIndex, 2);
-        manipulator->override_boolean_variable(sim, inIndex, false);
-        manipulator->override_string_variable(sim, inIndex, "foo");
+        manipulator->override_real_variable(sim, realInRef, 2.0);
+        manipulator->override_integer_variable(sim, intInRef, 2);
+        manipulator->override_boolean_variable(sim, boolInRef, true);
+        manipulator->override_string_variable(sim, stringInRef, "foo");
 
         execution.step();
 
-        observer->get_real(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&realInValue, 1));
-        observer->get_real(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&realOutValue, 1));
+        observer->get_real(sim, gsl::make_span(&realInRef, 1), gsl::make_span(&realInValue, 1));
+        observer->get_real(sim, gsl::make_span(&realOutRef, 1), gsl::make_span(&realOutValue, 1));
         REQUIRE(std::fabs(realInValue - 2.0) < 1.0e-9);
         REQUIRE(std::fabs(realOutValue - 3.234) < 1.0e-9);
 
-        observer->get_integer(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&intInValue, 1));
-        observer->get_integer(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&intOutValue, 1));
+        observer->get_integer(sim, gsl::make_span(&intInRef, 1), gsl::make_span(&intInValue, 1));
+        observer->get_integer(sim, gsl::make_span(&intOutRef, 1), gsl::make_span(&intOutValue, 1));
         REQUIRE(intInValue == 2);
         REQUIRE(intOutValue == 3);
 
-        observer->get_boolean(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&boolInValue, 1));
-        observer->get_boolean(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&boolOutValue, 1));
-        REQUIRE(boolInValue == false);
-        REQUIRE(boolOutValue == true);
+        observer->get_boolean(sim, gsl::make_span(&boolInRef, 1), gsl::make_span(&boolInValue, 1));
+        observer->get_boolean(sim, gsl::make_span(&boolOutRef, 1), gsl::make_span(&boolOutValue, 1));
+        REQUIRE(boolInValue == true);
+        REQUIRE(boolOutValue == false);
 
-        observer->get_string(sim, gsl::make_span(&inIndex, 1), gsl::make_span(&stringInValue, 1));
-        observer->get_string(sim, gsl::make_span(&outIndex, 1), gsl::make_span(&stringOutValue, 1));
+        observer->get_string(sim, gsl::make_span(&stringInRef, 1), gsl::make_span(&stringInValue, 1));
+        observer->get_string(sim, gsl::make_span(&stringOutRef, 1), gsl::make_span(&stringOutValue, 1));
         REQUIRE(stringInValue == "foo");
         REQUIRE(stringOutValue == "foobar");
 

--- a/test/cpp/mock_slave.hpp
+++ b/test/cpp/mock_slave.hpp
@@ -24,47 +24,76 @@
 class mock_slave : public cse::slave
 {
 public:
+    constexpr static cse::value_reference real_out_reference = 0;
+    constexpr static cse::value_reference real_in_reference = 1;
+    constexpr static cse::value_reference integer_out_reference = 0;
+    constexpr static cse::value_reference integer_in_reference = 1;
+    constexpr static cse::value_reference boolean_out_reference = 0;
+    constexpr static cse::value_reference boolean_in_reference = 1;
+    constexpr static cse::value_reference string_out_reference = 0;
+    constexpr static cse::value_reference string_in_reference = 1;
+
+    // Constructor that takes time-dependent functions
     explicit mock_slave(
-        std::function<double(double)> realOp = nullptr,
-        std::function<int(int)> intOp = nullptr,
-        std::function<bool(bool)> boolOp = nullptr,
-        std::function<std::string(std::string_view)> stringOp = nullptr)
+        std::function<double(cse::time_point, double)> realOp = nullptr,
+        std::function<int(cse::time_point, int)> intOp = nullptr,
+        std::function<bool(cse::time_point, bool)> boolOp = nullptr,
+        std::function<std::string(cse::time_point, std::string_view)> stringOp = nullptr,
+        std::function<void(cse::time_point)> stepAction = nullptr)
         : realOp_(std::move(realOp))
         , intOp_(std::move(intOp))
         , boolOp_(std::move(boolOp))
         , stringOp_(std::move(stringOp))
-        , realIn_(0.0)
-        , realOut_(1.0)
-        , intIn_(0)
-        , intOut_(1)
-        , boolIn_(true)
-        , boolOut_(false)
-        , stringIn_()
-        , stringOut_()
+        , stepAction_(std::move(stepAction))
     {
     }
+
+    // Constructor that takes time-independent functions (and wraps them in
+    // time-dependent ones).
+    explicit mock_slave(
+        std::function<double(double)> realOp,
+        std::function<int(int)> intOp = nullptr,
+        std::function<bool(bool)> boolOp = nullptr,
+        std::function<std::string(std::string_view)> stringOp = nullptr,
+        std::function<void()> stepAction = nullptr)
+        : realOp_(wrap_op(realOp))
+        , intOp_(wrap_op(intOp))
+        , boolOp_(wrap_op(boolOp))
+        , stringOp_(wrap_op(stringOp))
+        , stepAction_(wrap_op(stepAction))
+    {
+    }
+
+    template<typename R, typename... T>
+    static std::function<R(cse::time_point, T...)> wrap_op(std::function<R(T...)> timeIndependentOp)
+    {
+        if (!timeIndependentOp) return nullptr;
+        return [op = std::move(timeIndependentOp)](cse::time_point, T... value) { return op(value...); };
+    }
+
 
     cse::model_description model_description() const override
     {
         cse::model_description md;
         md.name = "mock_slave";
         md.uuid = "09b7ee06-fc07-4ad0-86f1-cd183fbae519";
-        md.variables.push_back(cse::variable_description{"realOut", 0, cse::variable_type::real, cse::variable_causality::output, cse::variable_variability::discrete, 0.0});
-        md.variables.push_back(cse::variable_description{"realIn", 1, cse::variable_type::real, cse::variable_causality::input, cse::variable_variability::discrete, 1.0});
-        md.variables.push_back(cse::variable_description{"intOut", 0, cse::variable_type::integer, cse::variable_causality::output, cse::variable_variability::discrete, std::nullopt});
-        md.variables.push_back(cse::variable_description{"intIn", 1, cse::variable_type::integer, cse::variable_causality::input, cse::variable_variability::discrete, 1});
-        md.variables.push_back(cse::variable_description{"stringOut", 0, cse::variable_type::string, cse::variable_causality::output, cse::variable_variability::discrete, std::string("hello")});
-        md.variables.push_back(cse::variable_description{"stringIn", 1, cse::variable_type::string, cse::variable_causality::input, cse::variable_variability::discrete, std::nullopt});
-        md.variables.push_back(cse::variable_description{"booleanOut", 0, cse::variable_type::boolean, cse::variable_causality::output, cse::variable_variability::discrete, false});
-        md.variables.push_back(cse::variable_description{"booleanIn", 1, cse::variable_type::boolean, cse::variable_causality::input, cse::variable_variability::discrete, true});
+        md.variables.push_back(cse::variable_description{"realOut", real_out_reference, cse::variable_type::real, cse::variable_causality::output, cse::variable_variability::discrete, std::nullopt});
+        md.variables.push_back(cse::variable_description{"realIn", real_in_reference, cse::variable_type::real, cse::variable_causality::input, cse::variable_variability::discrete, 0.0});
+        md.variables.push_back(cse::variable_description{"intOut", integer_out_reference, cse::variable_type::integer, cse::variable_causality::output, cse::variable_variability::discrete, std::nullopt});
+        md.variables.push_back(cse::variable_description{"intIn", integer_in_reference, cse::variable_type::integer, cse::variable_causality::input, cse::variable_variability::discrete, 0});
+        md.variables.push_back(cse::variable_description{"stringOut", string_out_reference, cse::variable_type::string, cse::variable_causality::output, cse::variable_variability::discrete, std::nullopt});
+        md.variables.push_back(cse::variable_description{"stringIn", string_in_reference, cse::variable_type::string, cse::variable_causality::input, cse::variable_variability::discrete, std::string()});
+        md.variables.push_back(cse::variable_description{"booleanOut", boolean_out_reference, cse::variable_type::boolean, cse::variable_causality::output, cse::variable_variability::discrete, std::nullopt});
+        md.variables.push_back(cse::variable_description{"booleanIn", boolean_in_reference, cse::variable_type::boolean, cse::variable_causality::input, cse::variable_variability::discrete, false});
         return md;
     }
 
     void setup(
-        cse::time_point /*startTime*/,
+        cse::time_point startTime,
         std::optional<cse::time_point> /*stopTime*/,
         std::optional<double> /*relativeTolerance*/) override
     {
+        currentTime_ = startTime;
     }
 
     void start_simulation() override
@@ -75,12 +104,10 @@ public:
     {
     }
 
-    cse::step_result do_step(cse::time_point /*currentT*/, cse::duration /*deltaT*/) override
+    cse::step_result do_step(cse::time_point currentT, cse::duration deltaT) override
     {
-        realOut_ = realOp_ ? realOp_(realIn_) : realIn_;
-        intOut_ = intOp_ ? intOp_(intIn_) : intIn_;
-        boolOut_ = boolOp_ ? boolOp_(boolIn_) : boolIn_;
-        stringOut_ = stringOp_ ? stringOp_(stringIn_) : stringIn_;
+        if (stepAction_) stepAction_(currentT);
+        currentTime_ = currentT + deltaT;
         return cse::step_result::complete;
     }
 
@@ -89,9 +116,9 @@ public:
         gsl::span<double> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) {
-                values[i] = realOut_;
-            } else if (variables[i] == 1) {
+            if (variables[i] == real_out_reference) {
+                values[i] = realOp_ ? realOp_(currentTime_, realIn_) : realIn_;
+            } else if (variables[i] == real_in_reference) {
                 values[i] = realIn_;
             } else {
                 throw std::out_of_range("bad reference");
@@ -104,9 +131,9 @@ public:
         gsl::span<int> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) {
-                values[i] = intOut_;
-            } else if (variables[i] == 1) {
+            if (variables[i] == integer_out_reference) {
+                values[i] = intOp_ ? intOp_(currentTime_, intIn_) : intIn_;
+            } else if (variables[i] == integer_in_reference) {
                 values[i] = intIn_;
             } else {
                 throw std::out_of_range("bad reference");
@@ -119,9 +146,9 @@ public:
         gsl::span<bool> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) {
-                values[i] = boolOut_;
-            } else if (variables[i] == 1) {
+            if (variables[i] == boolean_out_reference) {
+                values[i] = boolOp_ ? boolOp_(currentTime_, boolIn_) : boolIn_;
+            } else if (variables[i] == boolean_in_reference) {
                 values[i] = boolIn_;
             } else {
                 throw std::out_of_range("bad reference");
@@ -134,9 +161,9 @@ public:
         gsl::span<std::string> values) const override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 0) {
-                values[i] = stringOut_;
-            } else if (variables[i] == 1) {
+            if (variables[i] == string_out_reference) {
+                values[i] = stringOp_ ? stringOp_(currentTime_, stringIn_) : stringIn_;
+            } else if (variables[i] == string_in_reference) {
                 values[i] = stringIn_;
             } else {
                 throw std::out_of_range("bad reference");
@@ -149,7 +176,7 @@ public:
         gsl::span<const double> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 1) {
+            if (variables[i] == real_in_reference) {
                 realIn_ = values[i];
             } else {
                 throw std::out_of_range("bad reference");
@@ -162,7 +189,7 @@ public:
         gsl::span<const int> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 1) {
+            if (variables[i] == integer_in_reference) {
                 intIn_ = values[i];
             } else {
                 throw std::out_of_range("bad reference");
@@ -175,7 +202,7 @@ public:
         gsl::span<const bool> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 1) {
+            if (variables[i] == boolean_in_reference) {
                 boolIn_ = values[i];
             } else {
                 throw std::out_of_range("bad reference");
@@ -188,7 +215,7 @@ public:
         gsl::span<const std::string> values) override
     {
         for (int i = 0; i < variables.size(); ++i) {
-            if (variables[i] == 1) {
+            if (variables[i] == string_in_reference) {
                 stringIn_ = values[i];
             } else {
                 throw std::out_of_range("bad reference");
@@ -197,15 +224,18 @@ public:
     }
 
 private:
-    std::function<double(double)> realOp_;
-    std::function<int(int)> intOp_;
-    std::function<bool(bool)> boolOp_;
-    std::function<std::string(std::string_view)> stringOp_;
+    std::function<double(cse::time_point, double)> realOp_;
+    std::function<int(cse::time_point, int)> intOp_;
+    std::function<bool(cse::time_point, bool)> boolOp_;
+    std::function<std::string(cse::time_point, std::string_view)> stringOp_;
+    std::function<void(cse::time_point)> stepAction_;
 
-    double realIn_, realOut_;
-    int intIn_, intOut_;
-    bool boolIn_, boolOut_;
-    std::string stringIn_, stringOut_;
+    cse::time_point currentTime_;
+
+    double realIn_ = 0.0;
+    int intIn_ = 0;
+    bool boolIn_ = false;
+    std::string stringIn_;
 };
 
 

--- a/test/cpp/monitor_modified_variables_test.cpp
+++ b/test/cpp/monitor_modified_variables_test.cpp
@@ -37,9 +37,9 @@ int main()
                 [](int y) { return y + 2; })),
             "Slave");
 
-        observer->start_observing(cse::variable_id{simIndex, cse::variable_type::integer, 0});
+        observer->start_observing(cse::variable_id{simIndex, cse::variable_type::integer, mock_slave::integer_out_reference});
 
-        manipulator->override_integer_variable(simIndex, 0, 1);
+        manipulator->override_integer_variable(simIndex, mock_slave::integer_out_reference, 1);
 
         auto simResult = execution.simulate_until(endTime);
         REQUIRE(simResult.get());
@@ -49,7 +49,7 @@ int main()
         cse::step_number steps[numSamples];
         cse::time_point times[numSamples];
 
-        size_t samplesRead = observer->get_integer_samples(simIndex, 0, 1, gsl::make_span(intOutputValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(times, numSamples));
+        size_t samplesRead = observer->get_integer_samples(simIndex, mock_slave::integer_out_reference, 1, gsl::make_span(intOutputValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(times, numSamples));
         REQUIRE(samplesRead == 10);
 
         for (size_t i = 0; i < samplesRead; i++) {

--- a/test/cpp/multi_fixed_step_algorithm_test.cpp
+++ b/test/cpp/multi_fixed_step_algorithm_test.cpp
@@ -79,35 +79,30 @@ int main()
         auto observer = std::make_shared<cse::last_value_observer>();
         execution.add_observer(observer);
 
-        const cse::value_reference realOutIndex = 0;
-        const cse::value_reference realInIndex = 1;
-        const cse::value_reference integerOutIndex = 0;
-        const cse::value_reference integerInIndex = 1;
-
         double v = 0.0;
-        auto slave0 = std::make_shared<mock_slave>([&v](double /*x*/) { return ++v; });
+        auto slave0 = std::make_shared<mock_slave>([&v](double /*x*/) { return v; }, nullptr, nullptr, nullptr, [&v] { ++v; });
         auto idx0 = execution.add_slave(cse::make_pseudo_async(slave0), "slave 0");
 
         auto slave1 = std::make_shared<set_logging_mock_slave>();
         auto idx1 = execution.add_slave(cse::make_pseudo_async(slave1), "slave 1");
 
         int i = 0;
-        auto slave2 = std::make_shared<set_logging_mock_slave>(nullptr, [&i](int /*x*/) { return ++i + 1; });
+        auto slave2 = std::make_shared<set_logging_mock_slave>(nullptr, [&i](int /*x*/) { return i + 1; }, nullptr, nullptr, [&i] { ++i; });
         auto idx2 = execution.add_slave(cse::make_pseudo_async(slave2), "slave 2");
 
         auto c1 = std::make_shared<cse::scalar_connection>(
-            cse::variable_id{idx0, cse::variable_type::real, realOutIndex},
-            cse::variable_id{idx1, cse::variable_type::real, realInIndex});
+            cse::variable_id{idx0, cse::variable_type::real, mock_slave::real_out_reference},
+            cse::variable_id{idx1, cse::variable_type::real, mock_slave::real_in_reference});
         execution.add_connection(c1);
 
         auto c2 = std::make_shared<cse::scalar_connection>(
-            cse::variable_id{idx1, cse::variable_type::integer, integerOutIndex},
-            cse::variable_id{idx2, cse::variable_type::integer, integerInIndex});
+            cse::variable_id{idx1, cse::variable_type::integer, mock_slave::integer_out_reference},
+            cse::variable_id{idx2, cse::variable_type::integer, mock_slave::integer_in_reference});
         execution.add_connection(c2);
 
         auto c3 = std::make_shared<cse::scalar_connection>(
-            cse::variable_id{idx2, cse::variable_type::integer, integerOutIndex},
-            cse::variable_id{idx1, cse::variable_type::integer, integerInIndex});
+            cse::variable_id{idx2, cse::variable_type::integer, mock_slave::integer_out_reference},
+            cse::variable_id{idx1, cse::variable_type::integer, mock_slave::integer_in_reference});
         execution.add_connection(c3);
 
         algorithm->set_stepsize_decimation_factor(idx0, 1);
@@ -116,9 +111,9 @@ int main()
 
         auto observer2 = std::make_shared<cse::time_series_observer>();
         execution.add_observer(observer2);
-        observer2->start_observing(cse::variable_id{idx0, cse::variable_type::real, realOutIndex});
-        observer2->start_observing(cse::variable_id{idx1, cse::variable_type::real, realOutIndex});
-        observer2->start_observing(cse::variable_id{idx2, cse::variable_type::integer, integerOutIndex});
+        observer2->start_observing(cse::variable_id{idx0, cse::variable_type::real, mock_slave::real_out_reference});
+        observer2->start_observing(cse::variable_id{idx1, cse::variable_type::real, mock_slave::real_out_reference});
+        observer2->start_observing(cse::variable_id{idx2, cse::variable_type::integer, mock_slave::integer_out_reference});
 
         // Run simulation
         auto simResult = execution.simulate_until(endTime);
@@ -128,20 +123,20 @@ int main()
         double realValues0[numSamples];
         cse::step_number steps0[numSamples];
         cse::time_point timeValues0[numSamples];
-        observer2->get_real_samples(idx0, realOutIndex, 1, gsl::make_span(realValues0, numSamples), gsl::make_span(steps0, numSamples), gsl::make_span(timeValues0, numSamples));
+        observer2->get_real_samples(idx0, mock_slave::real_out_reference, 1, gsl::make_span(realValues0, numSamples), gsl::make_span(steps0, numSamples), gsl::make_span(timeValues0, numSamples));
 
         double realValues1[numSamples];
         cse::step_number steps1[numSamples];
         cse::time_point timeValues1[numSamples];
-        observer2->get_real_samples(idx1, realOutIndex, 1, gsl::make_span(realValues1, numSamples), gsl::make_span(steps1, numSamples), gsl::make_span(timeValues1, numSamples));
+        observer2->get_real_samples(idx1, mock_slave::real_out_reference, 1, gsl::make_span(realValues1, numSamples), gsl::make_span(steps1, numSamples), gsl::make_span(timeValues1, numSamples));
 
         double expectedReals0[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
-        double expectedReals1[] = {1.0, 2.0, 4.0, 6.0, 8.0};
+        double expectedReals1[] = {0.0, 2.0, 4.0, 6.0, 8.0};
 
         int intValues[numSamples];
         cse::step_number steps[numSamples];
         cse::time_point timeValues[numSamples];
-        observer2->get_integer_samples(idx2, integerOutIndex, 1, gsl::make_span(intValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(timeValues, numSamples));
+        observer2->get_integer_samples(idx2, mock_slave::integer_out_reference, 1, gsl::make_span(intValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(timeValues, numSamples));
 
         // int expectedInts[numSamples] = {0, 0, 2, 2, 2, 3, 3, 3, 4, 4}; // this is what we actually expect
         int expectedInts[] = {2, 3, 4};

--- a/test/cpp/scenario_parser_unittest.cpp
+++ b/test/cpp/scenario_parser_unittest.cpp
@@ -42,10 +42,14 @@ void test(const boost::filesystem::path& scenarioFile)
             [](int y) { return y + 2; })),
         "slave uno");
 
-    observer->start_observing(cse::variable_id{simIndex, cse::variable_type::real, 0});
-    observer->start_observing(cse::variable_id{simIndex, cse::variable_type::real, 1});
-    observer->start_observing(cse::variable_id{simIndex, cse::variable_type::integer, 0});
-    observer->start_observing(cse::variable_id{simIndex, cse::variable_type::integer, 1});
+    observer->start_observing(
+        cse::variable_id{simIndex, cse::variable_type::real, mock_slave::real_in_reference});
+    observer->start_observing(
+        cse::variable_id{simIndex, cse::variable_type::real, mock_slave::real_out_reference});
+    observer->start_observing(
+            cse::variable_id{simIndex, cse::variable_type::integer, mock_slave::integer_in_reference});
+    observer->start_observing(
+        cse::variable_id{simIndex, cse::variable_type::integer, mock_slave::integer_out_reference});
 
     scenarioManager->load_scenario(scenarioFile, startTime);
 
@@ -60,19 +64,43 @@ void test(const boost::filesystem::path& scenarioFile)
     cse::step_number steps[numSamples];
     cse::time_point times[numSamples];
 
-    size_t samplesRead = observer->get_real_samples(simIndex, 1, 1, gsl::make_span(realInputValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(times, numSamples));
+    size_t samplesRead = observer->get_real_samples(
+        simIndex,
+        mock_slave::real_in_reference,
+        1,
+        gsl::make_span(realInputValues, numSamples),
+        gsl::make_span(steps, numSamples),
+        gsl::make_span(times, numSamples));
     BOOST_CHECK(samplesRead == 11);
-    samplesRead = observer->get_real_samples(simIndex, 0, 1, gsl::make_span(realOutputValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(times, numSamples));
+    samplesRead = observer->get_real_samples(
+        simIndex,
+        mock_slave::real_out_reference,
+        1,
+        gsl::make_span(realOutputValues, numSamples),
+        gsl::make_span(steps, numSamples),
+        gsl::make_span(times, numSamples));
     BOOST_CHECK(samplesRead == 11);
-    samplesRead = observer->get_integer_samples(simIndex, 1, 1, gsl::make_span(intInputValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(times, numSamples));
+    samplesRead = observer->get_integer_samples(
+        simIndex,
+        mock_slave::integer_in_reference,
+        1,
+        gsl::make_span(intInputValues, numSamples),
+        gsl::make_span(steps, numSamples),
+        gsl::make_span(times, numSamples));
     BOOST_CHECK(samplesRead == 11);
-    samplesRead = observer->get_integer_samples(simIndex, 0, 1, gsl::make_span(intOutputValues, numSamples), gsl::make_span(steps, numSamples), gsl::make_span(times, numSamples));
+    samplesRead = observer->get_integer_samples(
+        simIndex,
+        mock_slave::integer_out_reference,
+        1,
+        gsl::make_span(intOutputValues, numSamples),
+        gsl::make_span(steps, numSamples),
+        gsl::make_span(times, numSamples));
     BOOST_CHECK(samplesRead == 11);
 
-    double expectedRealInputs[] = {0.0, 0.0, 0.0, 0.0, 0.0, 2.001, 2.001, 2.001, 2.001, 2.001, 1.0};
-    double expectedRealOutputs[] = {1.234, 1.234, -1.0, 1.234, 1.234, 3.235, 3.235, 3.235, 3.235, 3.235, 2.234};
-    int expectedIntInputs[] = {0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 1};
-    int expectedIntOutputs[] = {2, 2, 2, 2, 2, 2, 2, 4, 5, 5, 3};
+    double expectedRealInputs[] = {0.0, 0.0, 0.0, 0.0, 0.0, 1.001, 1.001, 1.001, 1.001, 1.001, 0.0};
+    double expectedRealOutputs[] = {1.234, 1.234, -1.0, 1.234, 1.234, 2.235, 2.235, 2.235, 2.235, 2.235, 1.234};
+    int expectedIntInputs[] = {0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 0};
+    int expectedIntOutputs[] = {2, 2, 2, 2, 2, 2, 2, 4, 5, 5, 2};
 
     for (size_t i = 0; i < samplesRead; i++) {
         BOOST_CHECK_CLOSE(realInputValues[i], expectedRealInputs[i], tolerance);


### PR DESCRIPTION
This fixes issue #538, "`mock_slave` violates assumptions, causing tests to be ill-defined".  Basically, what I've done is to make the user-supplied functions act on the outputs rather than on the internal states.

This had quite substantial effects on some of the tests, which depended on the wrong behaviour.  To compensate and, to some extent, restore the old behaviour in a "correct" way, I've had to add some new functionality to `mock_slave`, namely:

- The possibility to have outputs depend on time as well as inputs.
- The possibility to have a custom function called at each time step.

Finally, I've taken this opportunity to make some of the tests slightly more readable by replacing magic numbers with named variables/constants. This includes:

- Simulator indexes, which were assumed to be sequential in some tests
- Variable references, which were assumed to be 0 and 1 for  `mock_slave`'s variables

The magic numbers were making the tests hard to read, and therefore also to fix.  Besides, while the above assumptions are correct at the moment, that need not be the case in the future.