### PR TITLE
Add yet another library name to FindTHRIFT.cmake

### DIFF
--- a/cmake/FindTHRIFT.cmake
+++ b/cmake/FindTHRIFT.cmake
@@ -10,7 +10,7 @@
 find_path(THRIFT_INCLUDE_DIR NAMES thrift/Thrift.h)
 mark_as_advanced(THRIFT_INCLUDE_DIR)
 
-find_library(THRIFT_LIBRARY NAMES thrift thriftmd thriftmdd)
+find_library(THRIFT_LIBRARY NAMES thrift thriftd thriftmd thriftmdd)
 mark_as_advanced(THRIFT_LIBRARY)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
For some reason, the library name becomes `libthriftd.a` on my Linux box, so I needed this change to be able to build with FMU-proxy.