### PR TITLE
Validate initial variable values from OspSystemStructure

### DIFF
--- a/src/cosim/osp_config_parser.cpp
+++ b/src/cosim/osp_config_parser.cpp
@@ -922,7 +922,9 @@ osp_config load_osp_config(
             simulator.stepSize ? to_duration(*simulator.stepSize) : duration::zero());
 
         for (const auto& p : simulator.initialValues) {
-            config.initial_values.emplace(
+            add_variable_value(
+                config.initial_values,
+                config.system_structure,
                 full_variable_name(simulator.name, p.name),
                 p.value);
         }


### PR DESCRIPTION
Closes #597 

The problem described in the issue was most likely caused by instantiating an FMU and terminating it before initializing, again caused by attempting to apply an initial value for a non-existing variable after the FMU was loaded. `osp_config_parser` did not use the proper validating method when adding initial variable values to the system structure. 