### PR TITLE
Real time timer improvements

### DIFF
--- a/include/cosim/execution.hpp
+++ b/include/cosim/execution.hpp
@@ -291,8 +291,11 @@ public:
     /// Returns if this is a real time simulation
     bool is_real_time_simulation() const;
 
-    /// Returns the current real time factor
+    /// Returns the rolling average real time factor
     double get_measured_real_time_factor() const;
+
+    /// Returns the total average real time factor
+    double get_total_average_real_time_factor() const;
 
     /// Returns the current real time factor target
     double get_real_time_factor_target() const;

--- a/include/cosim/execution.hpp
+++ b/include/cosim/execution.hpp
@@ -15,6 +15,7 @@
 #include <cosim/model_description.hpp>
 #include <cosim/system_structure.hpp>
 #include <cosim/time.hpp>
+#include <cosim/timer.hpp>
 
 #include <boost/fiber/future.hpp>
 #include <boost/functional/hash.hpp>
@@ -279,26 +280,11 @@ public:
     /// Is the simulation loop currently running
     bool is_running() const noexcept;
 
-    /// Enables real time simulation
-    void enable_real_time_simulation();
+    /// Returns a pointer to an object containing real time configuration
+    const std::shared_ptr<real_time_config> get_real_time_config() const;
 
-    /// Disables real time simulation
-    void disable_real_time_simulation();
-
-    /// Sets the custom real time factor for the simulation
-    void set_real_time_factor_target(double realTimeFactor);
-
-    /// Returns if this is a real time simulation
-    bool is_real_time_simulation() const;
-
-    /// Returns the rolling average real time factor
-    double get_measured_real_time_factor() const;
-
-    /// Returns the total average real time factor
-    double get_total_average_real_time_factor() const;
-
-    /// Returns the current real time factor target
-    double get_real_time_factor_target() const;
+    /// Returns a pointer to an object containing real time metrics
+    std::shared_ptr<const real_time_metrics> get_real_time_metrics() const;
 
     /// Returns the simulator with the given index
     std::shared_ptr<const simulator> get_simulator(simulator_index index) const;

--- a/include/cosim/timer.hpp
+++ b/include/cosim/timer.hpp
@@ -16,6 +16,16 @@
 namespace cosim
 {
 
+struct timer_config{
+    bool real_time_simulation;
+    double real_time_factor_target;
+};
+
+struct real_time_info {
+    double rolling_average_real_time_factor;
+    double total_average_real_time_factor;
+};
+
 /**
  *  A class for controlling real-time execution.
  */
@@ -51,8 +61,11 @@ public:
     /// Returns if this is a real time simulation
     bool is_real_time_simulation() const;
 
-    /// Returns the current real time factor
+    /// Returns the rolling average real time factor
     double get_measured_real_time_factor() const;
+
+    /// Returns the total average real time factor
+    double get_total_average_real_time_factor() const;
 
     /// Sets a custom real time factor
     void set_real_time_factor_target(double realTimeFactor);

--- a/include/cosim/timer.hpp
+++ b/include/cosim/timer.hpp
@@ -23,19 +23,22 @@ class real_time_timer;
 class real_time_config
 {
 public:
-    /// Toggles real time execution.
+    /// Toggles real-time-synchronized simulation on or off.
     void set_real_time_simulation(bool enable);
 
-    /// Returns if this is a real time simulation
+    /// Returns if this is a real-time-synchronized simulation.
     bool is_real_time_simulation() const;
 
-    /// Sets a custom real time factor
+    /// Sets the real time factor target used for real-time-synchronized simulation.
     void set_real_time_factor_target(double factor);
 
-    /// Returns the current real time factor target
+    /// Returns the real time factor target used for real-time-synchronized simulation.
     double get_real_time_factor_target() const;
 
-    /// Set the number of steps to use in the rolling average real time factor calculation.
+    /**
+     * Sets the number of steps to use in the rolling average real time factor calculation.
+     * This value is used for monitoring purposes only.
+     */
     void set_steps_to_monitor(int steps);
 
     /// Returns the number of steps used in the rolling average real time factor calculation.
@@ -53,9 +56,9 @@ private:
 /// A struct containing real time metrics.
 struct real_time_metrics
 {
-    /// The current rolling average real time factor.
+    /// The current rolling average real time factor measurement.
     std::atomic<double> rolling_average_real_time_factor = 1.0;
-    /// The total average real time factor since the simulation was started.
+    /// The total average real time factor measurement since the simulation was started.
     std::atomic<double> total_average_real_time_factor = 1.0;
 };
 

--- a/include/cosim/timer.hpp
+++ b/include/cosim/timer.hpp
@@ -11,19 +11,52 @@
 
 #include <cosim/time.hpp>
 
+#include <atomic>
 #include <memory>
 
 namespace cosim
 {
 
-struct timer_config{
-    bool real_time_simulation;
-    double real_time_factor_target;
+class real_time_timer;
+
+/// A class containing real time execution configuration.
+class real_time_config
+{
+public:
+    /// Toggles real time execution.
+    void set_real_time_simulation(bool enable);
+
+    /// Returns if this is a real time simulation
+    bool is_real_time_simulation() const;
+
+    /// Sets a custom real time factor
+    void set_real_time_factor_target(double factor);
+
+    /// Returns the current real time factor target
+    double get_real_time_factor_target() const;
+
+    /// Set the number of steps to use in the rolling average real time factor calculation.
+    void set_steps_to_monitor(int steps);
+
+    /// Returns the number of steps used in the rolling average real time factor calculation.
+    int get_steps_to_monitor() const;
+
+private:
+    friend class real_time_timer;
+
+    std::atomic<bool> configChanged_ = false;
+    std::atomic<bool> realTimeSimulation_ = false;
+    std::atomic<double> realTimeFactorTarget_ = 1.0;
+    std::atomic<int> stepsToMonitor_ = 5;
 };
 
-struct real_time_info {
-    double rolling_average_real_time_factor;
-    double total_average_real_time_factor;
+/// A struct containing real time metrics.
+struct real_time_metrics
+{
+    /// The current rolling average real time factor.
+    std::atomic<double> rolling_average_real_time_factor = 1.0;
+    /// The total average real time factor since the simulation was started.
+    std::atomic<double> total_average_real_time_factor = 1.0;
 };
 
 /**
@@ -52,26 +85,10 @@ public:
      */
     void sleep(time_point currentTime);
 
-    /// Enables real time simulation
-    void enable_real_time_simulation();
+    std::shared_ptr<real_time_config> get_real_time_config() const;
 
-    /// Disables real time simulation
-    void disable_real_time_simulation();
-
-    /// Returns if this is a real time simulation
-    bool is_real_time_simulation() const;
-
-    /// Returns the rolling average real time factor
-    double get_measured_real_time_factor() const;
-
-    /// Returns the total average real time factor
-    double get_total_average_real_time_factor() const;
-
-    /// Sets a custom real time factor
-    void set_real_time_factor_target(double realTimeFactor);
-
-    /// Returns the current real time factor target
-    double get_real_time_factor_target() const;
+    /// Returns a pointer to an object containing real time metrics
+    std::shared_ptr<const real_time_metrics> get_real_time_metrics() const;
 
     /// Constructor
     real_time_timer();

--- a/include/cosim/timer.hpp
+++ b/include/cosim/timer.hpp
@@ -51,9 +51,9 @@ public:
     std::size_t operator()(const cosim::real_time_config& v) const noexcept
     {
         std::size_t seed = 0;
-        boost::hash_combine(seed, v.real_time_simulation);
-        boost::hash_combine(seed, v.real_time_factor_target);
-        boost::hash_combine(seed, v.steps_to_monitor);
+        boost::hash_combine(seed, v.real_time_simulation.load());
+        boost::hash_combine(seed, v.real_time_factor_target.load());
+        boost::hash_combine(seed, v.steps_to_monitor.load());
         return seed;
     }
 };

--- a/src/cosim/execution.cpp
+++ b/src/cosim/execution.cpp
@@ -182,6 +182,11 @@ public:
         return timer_.get_measured_real_time_factor();
     }
 
+    double get_total_average_real_time_factor() const
+    {
+        return timer_.get_total_average_real_time_factor();
+    }
+
     void set_real_time_factor_target(double realTimeFactor)
     {
         timer_.set_real_time_factor_target(realTimeFactor);
@@ -432,6 +437,11 @@ bool execution::is_real_time_simulation() const
 double execution::get_measured_real_time_factor() const
 {
     return pimpl_->get_measured_real_time_factor();
+}
+
+double execution::get_total_average_real_time_factor() const
+{
+    return pimpl_->get_total_average_real_time_factor();
 }
 
 void execution::set_real_time_factor_target(double realTimeFactor)

--- a/src/cosim/execution.cpp
+++ b/src/cosim/execution.cpp
@@ -8,7 +8,6 @@
 #include "cosim/algorithm.hpp"
 #include "cosim/exception.hpp"
 #include "cosim/slave_simulator.hpp"
-#include "cosim/timer.hpp"
 #include "cosim/utility/utility.hpp"
 
 #include <algorithm>
@@ -162,39 +161,14 @@ public:
         stopped_ = true;
     }
 
-    void enable_real_time_simulation()
+    std::shared_ptr<real_time_config> get_real_time_config() const
     {
-        timer_.enable_real_time_simulation();
+        return timer_.get_real_time_config();
     }
 
-    void disable_real_time_simulation()
+    std::shared_ptr<const real_time_metrics> get_real_time_metrics() const
     {
-        timer_.disable_real_time_simulation();
-    }
-
-    bool is_real_time_simulation() const
-    {
-        return timer_.is_real_time_simulation();
-    }
-
-    double get_measured_real_time_factor() const
-    {
-        return timer_.get_measured_real_time_factor();
-    }
-
-    double get_total_average_real_time_factor() const
-    {
-        return timer_.get_total_average_real_time_factor();
-    }
-
-    void set_real_time_factor_target(double realTimeFactor)
-    {
-        timer_.set_real_time_factor_target(realTimeFactor);
-    }
-
-    double get_real_time_factor_target() const
-    {
-        return timer_.get_real_time_factor_target();
+        return timer_.get_real_time_metrics();
     }
 
     std::shared_ptr<const simulator> get_simulator(simulator_index index) const
@@ -419,39 +393,14 @@ void execution::stop_simulation()
     pimpl_->stop_simulation();
 }
 
-void execution::enable_real_time_simulation()
+const std::shared_ptr<real_time_config> execution::get_real_time_config() const
 {
-    pimpl_->enable_real_time_simulation();
+    return pimpl_->get_real_time_config();
 }
 
-void execution::disable_real_time_simulation()
+std::shared_ptr<const real_time_metrics> execution::get_real_time_metrics() const
 {
-    pimpl_->disable_real_time_simulation();
-}
-
-bool execution::is_real_time_simulation() const
-{
-    return pimpl_->is_real_time_simulation();
-}
-
-double execution::get_measured_real_time_factor() const
-{
-    return pimpl_->get_measured_real_time_factor();
-}
-
-double execution::get_total_average_real_time_factor() const
-{
-    return pimpl_->get_total_average_real_time_factor();
-}
-
-void execution::set_real_time_factor_target(double realTimeFactor)
-{
-    pimpl_->set_real_time_factor_target(realTimeFactor);
-}
-
-double execution::get_real_time_factor_target() const
-{
-    return pimpl_->get_real_time_factor_target();
+    return pimpl_->get_real_time_metrics();
 }
 
 std::shared_ptr<const simulator> execution::get_simulator(

--- a/src/cosim/timer.cpp
+++ b/src/cosim/timer.cpp
@@ -39,9 +39,10 @@ public:
             start(currentTime);
             configHashValue_ = newHash;
         }
-        if (config_->real_time_simulation && config_->real_time_factor_target.load() > 0.0) {
+        double rtfTarget = config_->real_time_factor_target.load();
+        if (config_->real_time_simulation && rtfTarget > 0.0) {
             const auto elapsed = Time::now() - startTime_;
-            const auto expectedSimulationTime = (currentTime - simulationStartTime_) / config_->real_time_factor_target.load();
+            const auto expectedSimulationTime = (currentTime - simulationStartTime_) / rtfTarget;
             const auto simulationSleepTime = expectedSimulationTime - elapsed;
 
             if (simulationSleepTime > MIN_SLEEP) {

--- a/tests/fixed_step_algorithm_test.cpp
+++ b/tests/fixed_step_algorithm_test.cpp
@@ -7,7 +7,6 @@
 #include <cosim/observer/last_value_observer.hpp>
 #include <cosim/observer/time_series_observer.hpp>
 
-#include <cmath>
 #include <exception>
 #include <memory>
 #include <stdexcept>
@@ -36,7 +35,7 @@ int main()
 
         // Default should not be real time
         const auto realTimeConfig = execution.get_real_time_config();
-        REQUIRE(!realTimeConfig->is_real_time_simulation());
+        REQUIRE(!realTimeConfig->real_time_simulation);
 
         auto observer = std::make_shared<cosim::last_value_observer>();
         execution.add_observer(observer);
@@ -107,12 +106,11 @@ int main()
         // Run for another period with an RTF target > 1
         constexpr auto finalTime = cosim::to_time_point(2.0);
         constexpr double rtfTarget = 2.25;
-        realTimeConfig->set_real_time_simulation(true);
-        realTimeConfig->set_real_time_factor_target(rtfTarget);
-        realTimeConfig->set_steps_to_monitor(1);
+        realTimeConfig->real_time_simulation = true;
+        realTimeConfig->real_time_factor_target = rtfTarget;
+        realTimeConfig->steps_to_monitor = 3;
         simResult = execution.simulate_until(finalTime);
         REQUIRE(simResult.get());
-        REQUIRE(std::fabs(realTimeConfig->get_real_time_factor_target() - rtfTarget) < 1.0e-9);
 
         std::cout << "Rolling average RTF: " << realTimeMetrics->rolling_average_real_time_factor << std::endl;
         std::cout << "  Total average RTF: " << realTimeMetrics->total_average_real_time_factor << std::endl;

--- a/tests/fixed_step_algorithm_test.cpp
+++ b/tests/fixed_step_algorithm_test.cpp
@@ -35,7 +35,8 @@ int main()
             std::make_unique<cosim::fixed_step_algorithm>(stepSize));
 
         // Default should not be real time
-        REQUIRE(!execution.is_real_time_simulation());
+        const auto realTimeConfig = execution.get_real_time_config();
+        REQUIRE(!realTimeConfig->is_real_time_simulation());
 
         auto observer = std::make_shared<cosim::last_value_observer>();
         execution.add_observer(observer);
@@ -77,7 +78,10 @@ int main()
         REQUIRE(simResult.get());
         REQUIRE(std::chrono::abs(execution.current_time() - midTime) < std::chrono::microseconds(1));
         // Actual performance should not be tested here - just check that we get a positive value
-        REQUIRE(execution.get_measured_real_time_factor() > 0.0);
+        const auto realTimeMetrics = execution.get_real_time_metrics();
+        REQUIRE(realTimeMetrics->rolling_average_real_time_factor > 0.0);
+        REQUIRE(realTimeMetrics->total_average_real_time_factor > 0.0);
+
         simResult = execution.simulate_until(endTime);
         REQUIRE(simResult.get());
 
@@ -103,11 +107,15 @@ int main()
         // Run for another period with an RTF target > 1
         constexpr auto finalTime = cosim::to_time_point(2.0);
         constexpr double rtfTarget = 2.25;
-        execution.enable_real_time_simulation();
-        execution.set_real_time_factor_target(rtfTarget);
+        realTimeConfig->set_real_time_simulation(true);
+        realTimeConfig->set_real_time_factor_target(rtfTarget);
+        realTimeConfig->set_steps_to_monitor(1);
         simResult = execution.simulate_until(finalTime);
         REQUIRE(simResult.get());
-        REQUIRE(std::fabs(execution.get_real_time_factor_target() - rtfTarget) < 1.0e-9);
+        REQUIRE(std::fabs(realTimeConfig->get_real_time_factor_target() - rtfTarget) < 1.0e-9);
+
+        std::cout << "Rolling average RTF: " << realTimeMetrics->rolling_average_real_time_factor << std::endl;
+        std::cout << "  Total average RTF: " << realTimeMetrics->total_average_real_time_factor << std::endl;
 
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;


### PR DESCRIPTION
This is an attempt to fix #298, measured real time factor is wrong.

Two new features are introduced:
- Number of steps used in the rolling average RTF calculation is now configurable.
- Total average real time factor (since start of simulation or real time factor toggling) is calculated and exposed to the outside.

I was not happy with the growing amount of timer-related methods delegated through the `execution` class, so I introduced two new data classes:
- `real_time_config` for toggling real time simulation, setting RTF target etc.
- `real_time_metrics` for monitoring of real time performance.

Please let me know if this was a bad idea and/or implementation!

Will create separate PR's for client code if this gets approved.