### PR TITLE
Update thrift (0.13.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ find_package(LIBZIP REQUIRED)
 find_package(YAML_CPP REQUIRED)
 find_package(XercesC REQUIRED)
 if(LIBCOSIM_WITH_FMUPROXY)
-    find_package(THRIFT REQUIRED)
+    find_package(THRIFT 0.13.0 REQUIRED)
 endif()
 
 # ==============================================================================

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,11 +48,11 @@ class LibcosimConan(ConanFile):
 
     def requirements(self):
         if self.options.fmuproxy:
-            self.requires("thrift/0.12.0@bincrafters/stable")
+            self.requires("thrift/0.13.0")
 
     def build_requirements(self):
         if self.options.fmuproxy:
-            self.build_requires("thrift_installer/0.12.0@bincrafters/stable")
+            self.build_requires("thrift_installer/0.13.0@bincrafters/stable")
 
     def configure_cmake(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -50,10 +50,6 @@ class LibcosimConan(ConanFile):
         if self.options.fmuproxy:
             self.requires("thrift/0.13.0")
 
-    def build_requirements(self):
-        if self.options.fmuproxy:
-            self.build_requires("thrift_installer/0.13.0@bincrafters/stable")
-
     def configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["LIBCOSIM_USING_CONAN"] = "ON"

--- a/src/cosim/fmuproxy/fmuproxy_client.cpp
+++ b/src/cosim/fmuproxy/fmuproxy_client.cpp
@@ -55,18 +55,17 @@ void read_data(const std::string& fileName, std::string& data)
 
 } // namespace
 
-cosim::fmuproxy::fmuproxy_client::fmuproxy_client(const std::string& host, const unsigned int port,
-    const bool concurrent)
+cosim::fmuproxy::fmuproxy_client::fmuproxy_client(
+    const std::string& host,
+    const unsigned int port)
 {
     std::shared_ptr<TTransport> socket(new TSocket(host, port));
     std::shared_ptr<TTransport> transport(new TFramedTransport(socket));
     std::shared_ptr<TProtocol> protocol(new TBinaryProtocol(transport));
     std::shared_ptr<::fmuproxy::thrift::FmuServiceIf> client;
-    if (!concurrent) {
-        client = std::make_shared<FmuServiceClient>(protocol);
-    } else {
-        client = std::make_shared<FmuServiceConcurrentClient>(protocol);
-    }
+
+    client = std::make_shared<FmuServiceClient>(protocol);
+
     try {
         transport->open();
     } catch (TTransportException&) {

--- a/src/cosim/fmuproxy/fmuproxy_client.hpp
+++ b/src/cosim/fmuproxy/fmuproxy_client.hpp
@@ -26,9 +26,9 @@ class fmuproxy_client
 {
 
 public:
-    fmuproxy_client(const std::string& host,
-        unsigned int port,
-        bool concurrent = false);
+    fmuproxy_client(
+        const std::string& host,
+        unsigned int port);
 
     std::shared_ptr<remote_fmu> from_url(const std::string& url);
 


### PR DESCRIPTION
Updates thrift to 0.13.0

Even with the change, libcosim is still compatible with fmu-proxy 0.61, 0.6.2