### PR TITLE
Updated OspSystemStructure.xsd to allow empty sequence of InitialValues

### DIFF
--- a/data/xsd/OspSystemStructure.xsd
+++ b/data/xsd/OspSystemStructure.xsd
@@ -5,7 +5,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
            targetNamespace="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
            xmlns:osp="http://opensimulationplatform.com/MSMI/OSPSystemStructure"
-           version="0.1">
+           version="0.1.1">
     <xs:element name="OspSystemStructure">
         <xs:complexType>
             <xs:sequence>
@@ -73,7 +73,7 @@
                         <xs:element name="InitialValues" minOccurs="0">
                             <xs:complexType>
                                 <xs:sequence>
-                                    <xs:element name="InitialValue" maxOccurs="unbounded">
+                                    <xs:element name="InitialValue" minOccurs="0" maxOccurs="unbounded">
                                         <xs:complexType>
                                             <xs:choice>
                                                 <xs:element name="Real">

--- a/tests/data/msmi/OspSystemStructure.xml
+++ b/tests/data/msmi/OspSystemStructure.xml
@@ -18,7 +18,9 @@
                 </InitialValue>
             </InitialValues>
         </Simulator>
-        <Simulator name="KnuckleBoomCrane" source="../ssp/demo/KnuckleBoomCrane.fmu" stepSize="2.03e-4"/>
+        <Simulator name="KnuckleBoomCrane" source="../ssp/demo/KnuckleBoomCrane.fmu" stepSize="2.03e-4">
+            <InitialValues/>
+        </Simulator>
         <Simulator name="TrueIdentity" source="../fmi1/identity.fmu" stepSize="2.03e-4">
             <InitialValues>
                 <InitialValue variable="booleanIn">


### PR DESCRIPTION
This change should fix #612 by now allowing the OspSystemStructure.xml to contain en empty sequence of `<InitialValues/>`. Test data OspSystemStructure.xml also updated to make sure this is covered with unit test `osp_config_parser_test`.