### PR TITLE
Upgraded libzip dependency to new version available in ConanCenter

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,13 +19,9 @@ class LibcosimConan(ConanFile):
         "boost/1.71.0",
         "fmilibrary/2.0.3",
         "ms-gsl/2.1.0",
-        "libzip/1.5.2@bincrafters/stable",
+        "libzip/1.7.3",
         "yaml-cpp/0.6.3",
-        "xerces-c/3.2.2",
-        # Only for conflict resolution
-        "bzip2/1.0.8",
-        "openssl/1.0.2u",
-        "zlib/1.2.11",
+        "xerces-c/3.2.2"
     )
 
     options = {"fmuproxy": [True, False]}


### PR DESCRIPTION
Upgraded the libzip conan dependency to 1.7.3, that is now available through ConanCenter. The previoius version 1.5.2 available through bincrafters is now marked obsolete. The transitive dependencies of the new version is compatible with the rest of our dependencies and I could remove the dependency conflict resolution as well. This also resolves some runtime issues when linking an executable with both libcosim and Poco(with transitive openssl) from ConanCenter.
