### PR TITLE
Fix link to conan repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ following these steps:
 * Install [Conan] >= 1.7
 * Add the OSP Conan repository as a remote: 
 
-       conan remote add osp https://osp.jfrog.io/artifactory/api/conan/local
+       conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public
 * Package revisions must be enabled. See [How to activate the revisions].
 * Include libcosim as a requirement in your conanfile 
 * Run `conan install` to aquire the libcosim package

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ following these steps:
 * Add the OSP Conan repository as a remote: 
 
        conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local
-* Package revisions must be enabled. See [How to activate the revisions].
 * Include libcosim as a requirement in your conanfile 
 * Run `conan install` to aquire the libcosim package
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ following these steps:
 * Install [Conan] >= 1.7
 * Add the OSP Conan repository as a remote: 
 
-       conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-public
+       conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local
 * Package revisions must be enabled. See [How to activate the revisions].
 * Include libcosim as a requirement in your conanfile 
 * Run `conan install` to aquire the libcosim package


### PR DESCRIPTION
Old URL was https://osp.jfrog.io/artifactory/api/conan/local
The correct one is ~https://osp.jfrog.io/artifactory/api/conan/conan-public~ https://osp.jfrog.io/artifactory/api/conan/conan-local