### PR TITLE
Refactor/fmu

### DIFF
--- a/include/cosim/fmi/v1/fmu.hpp
+++ b/include/cosim/fmi/v1/fmu.hpp
@@ -67,7 +67,7 @@ public:
     fmu(fmu&&) = delete;
     fmu& operator=(fmu&&) = delete;
 
-    ~fmu();
+    ~fmu() override;
 
     // fmi::fmu methods
     fmi::fmi_version fmi_version() const override;
@@ -129,7 +129,7 @@ public:
     slave_instance(slave_instance&&) = delete;
     slave_instance& operator=(slave_instance&&) = delete;
 
-    ~slave_instance() noexcept;
+    ~slave_instance() noexcept override;
 
     // cosim::slave methods
     void setup(
@@ -180,7 +180,6 @@ public:
 
 private:
     std::shared_ptr<v1::fmu> fmu_;
-    fmi1_import_t* handle_;
 
     bool simStarted_ = false;
 

--- a/include/cosim/fmi/v2/fmu.hpp
+++ b/include/cosim/fmi/v2/fmu.hpp
@@ -67,7 +67,7 @@ public:
     fmu(fmu&&) = delete;
     fmu& operator=(fmu&&) = delete;
 
-    ~fmu();
+    ~fmu() override;
 
     // fmi::fmu methods
     fmi::fmi_version fmi_version() const override;
@@ -129,7 +129,7 @@ public:
     slave_instance(slave_instance&&) = delete;
     slave_instance& operator=(slave_instance&&) = delete;
 
-    ~slave_instance() noexcept;
+    ~slave_instance() noexcept override;
 
     // cosim::slave methods
     void setup(
@@ -180,7 +180,6 @@ public:
 
 private:
     std::shared_ptr<v2::fmu> fmu_;
-    fmi2_import_t* handle_;
 
     bool setupComplete_ = false;
     bool simStarted_ = false;

--- a/src/cosim/fmi/v1/fmu.cpp
+++ b/src/cosim/fmi/v1/fmu.cpp
@@ -165,9 +165,8 @@ fmu::fmu(
     callbacks.logger = log_message;
     callbacks.stepFinished = step_finished_placeholder;
 
-    if (fmi1_import_create_dllfmu(fmilib_handle(), callbacks, false) != jm_status_success) {
+    if (fmi1_import_create_dllfmu(handle_, callbacks, false) != jm_status_success) {
         const auto msg = importer_->last_error_message();
-        fmi1_import_free(fmilib_handle());
         throw error(
             make_error_code(errc::dl_load_error),
             importer_->last_error_message());

--- a/src/cosim/fmi/v2/fmu.cpp
+++ b/src/cosim/fmi/v2/fmu.cpp
@@ -26,7 +26,6 @@
 #include <unordered_map>
 #include <vector>
 
-
 namespace cosim
 {
 namespace fmi
@@ -37,6 +36,106 @@ namespace v2
 // =============================================================================
 // fmu
 // =============================================================================
+
+namespace
+{
+void step_finished_placeholder(fmi2_component_environment_t, fmi2_status_t)
+{
+    BOOST_LOG_SEV(log::logger(), log::debug)
+        << "FMU instance completed asynchronous step, "
+           "but this feature is currently not supported";
+}
+
+struct log_record
+{
+    log_record() { }
+    log_record(fmi2_status_t s, const std::string& m)
+        : status{s}
+        , message(m)
+    { }
+    fmi2_status_t status = fmi2_status_ok;
+    std::string message;
+};
+std::unordered_map<std::string, log_record> g_logRecords;
+std::mutex g_logMutex;
+
+void log_message(
+    fmi2_component_environment_t,
+    fmi2_string_t instanceName,
+    fmi2_status_t status,
+    fmi2_string_t category,
+    fmi2_string_t message,
+    ...)
+{
+    std::va_list args;
+        va_start(args, message);
+    const auto msgLength = std::vsnprintf(nullptr, 0, message, args);
+        va_end(args);
+    auto msgBuffer = std::vector<char>(msgLength + 1);
+        va_start(args, message);
+    std::vsnprintf(msgBuffer.data(), msgBuffer.size(), message, args);
+        va_end(args);
+    assert(msgBuffer.back() == '\0');
+
+    std::string statusName = "unknown";
+    log::severity_level logLevel = log::error;
+    switch (status) {
+        case fmi2_status_ok:
+            statusName = "ok";
+            logLevel = log::trace;
+            break;
+        case fmi2_status_warning:
+            statusName = "warning";
+            logLevel = log::warning;
+            break;
+        case fmi2_status_discard:
+            // Don't know if this ever happens, but we should at least
+            // print a debug message if it does.
+            statusName = "discard";
+            logLevel = log::debug;
+            break;
+        case fmi2_status_error:
+            statusName = "error";
+            logLevel = log::error;
+            break;
+        case fmi2_status_fatal:
+            statusName = "fatal";
+            logLevel = log::error;
+            break;
+        case fmi2_status_pending:
+            // Don't know if this ever happens, but we should at least
+            // print a debug message if it does.
+            statusName = "pending";
+            logLevel = log::debug;
+            break;
+    }
+    BOOST_LOG_SEV(log::logger(), logLevel)
+        << "[FMI status=" << statusName << ", category=" << category << "] "
+        << msgBuffer.data();
+
+    g_logMutex.lock();
+    g_logRecords[instanceName] =
+        log_record{status, std::string(msgBuffer.data())};
+    g_logMutex.unlock();
+}
+
+log_record last_log_record(const std::string& instanceName)
+{
+    std::lock_guard<std::mutex> lock(g_logMutex);
+    const auto it = g_logRecords.find(instanceName);
+    if (it == g_logRecords.end()) {
+        return log_record{};
+    } else {
+        // Note the use of c_str() here, to force the string to be copied.
+        // The C++ standard now disallows copy-on-write, but some compilers
+        // still use it, which could lead to problems in multithreaded
+        // programs.
+        return log_record{
+            it->second.status,
+            std::string(it->second.message.c_str())};
+    }
+}
+} // namespace
 
 fmu::fmu(
     std::shared_ptr<fmi::importer> importer,
@@ -55,6 +154,22 @@ fmu::fmu(
         throw error(
             make_error_code(errc::unsupported_feature),
             "Not a co-simulation FMU");
+    }
+
+
+    fmi2_callback_functions_t callbacks;
+    callbacks.allocateMemory = std::calloc;
+    callbacks.freeMemory = std::free;
+    callbacks.logger = log_message;
+    callbacks.stepFinished = step_finished_placeholder;
+    callbacks.componentEnvironment = nullptr;
+
+    if (fmi2_import_create_dllfmu(fmilib_handle(), fmi2_fmu_kind_cs, &callbacks) != jm_status_success) {
+        const auto msg = importer_->last_error_message();
+        fmi2_import_free(fmilib_handle());
+        throw error(
+            make_error_code(errc::dl_load_error),
+            importer_->last_error_message());
     }
 
     modelDescription_.name = fmi2_import_get_model_name(handle_);
@@ -83,6 +198,7 @@ fmu::fmu(
 
 fmu::~fmu()
 {
+    fmi2_import_destroy_dllfmu(fmilib_handle());
     fmi2_import_free(handle_);
 }
 
@@ -162,145 +278,21 @@ fmi2_import_t* fmu::fmilib_handle() const
 // slave_instance
 // =============================================================================
 
-namespace
-{
-void step_finished_placeholder(fmi2_component_environment_t, fmi2_status_t)
-{
-    BOOST_LOG_SEV(log::logger(), log::debug)
-        << "FMU instance completed asynchronous step, "
-           "but this feature is currently not supported";
-}
-
-struct log_record
-{
-    log_record() { }
-    log_record(fmi2_status_t s, const std::string& m)
-        : status{s}
-        , message(m)
-    { }
-    fmi2_status_t status = fmi2_status_ok;
-    std::string message;
-};
-std::unordered_map<std::string, log_record> g_logRecords;
-std::mutex g_logMutex;
-
-void log_message(
-    fmi2_component_environment_t,
-    fmi2_string_t instanceName,
-    fmi2_status_t status,
-    fmi2_string_t category,
-    fmi2_string_t message,
-    ...)
-{
-    std::va_list args;
-    va_start(args, message);
-    const auto msgLength = std::vsnprintf(nullptr, 0, message, args);
-    va_end(args);
-    auto msgBuffer = std::vector<char>(msgLength + 1);
-    va_start(args, message);
-    std::vsnprintf(msgBuffer.data(), msgBuffer.size(), message, args);
-    va_end(args);
-    assert(msgBuffer.back() == '\0');
-
-    std::string statusName = "unknown";
-    log::severity_level logLevel = log::error;
-    switch (status) {
-        case fmi2_status_ok:
-            statusName = "ok";
-            logLevel = log::trace;
-            break;
-        case fmi2_status_warning:
-            statusName = "warning";
-            logLevel = log::warning;
-            break;
-        case fmi2_status_discard:
-            // Don't know if this ever happens, but we should at least
-            // print a debug message if it does.
-            statusName = "discard";
-            logLevel = log::debug;
-            break;
-        case fmi2_status_error:
-            statusName = "error";
-            logLevel = log::error;
-            break;
-        case fmi2_status_fatal:
-            statusName = "fatal";
-            logLevel = log::error;
-            break;
-        case fmi2_status_pending:
-            // Don't know if this ever happens, but we should at least
-            // print a debug message if it does.
-            statusName = "pending";
-            logLevel = log::debug;
-            break;
-    }
-    BOOST_LOG_SEV(log::logger(), logLevel)
-        << "[FMI status=" << statusName << ", category=" << category << "] "
-        << msgBuffer.data();
-
-    g_logMutex.lock();
-    g_logRecords[instanceName] =
-        log_record{status, std::string(msgBuffer.data())};
-    g_logMutex.unlock();
-}
-
-log_record last_log_record(const std::string& instanceName)
-{
-    std::lock_guard<std::mutex> lock(g_logMutex);
-    const auto it = g_logRecords.find(instanceName);
-    if (it == g_logRecords.end()) {
-        return log_record{};
-    } else {
-        // Note the use of c_str() here, to force the string to be copied.
-        // The C++ standard now disallows copy-on-write, but some compilers
-        // still use it, which could lead to problems in multithreaded
-        // programs.
-        return log_record{
-            it->second.status,
-            std::string(it->second.message.c_str())};
-    }
-}
-} // namespace
-
-
 slave_instance::slave_instance(
     std::shared_ptr<v2::fmu> fmu,
     std::string_view instanceName)
     : fmu_{fmu}
-    , handle_{fmi2_import_parse_xml(fmu->importer()->fmilib_handle(), fmu->directory().string().c_str(), nullptr)}
     , instanceName_(instanceName)
 {
     assert(!instanceName.empty());
-    if (handle_ == nullptr) {
-        throw error(
-            make_error_code(errc::bad_file),
-            fmu->importer()->last_error_message());
-    }
-
-    fmi2_callback_functions_t callbacks;
-    callbacks.allocateMemory = std::calloc;
-    callbacks.freeMemory = std::free;
-    callbacks.logger = log_message;
-    callbacks.stepFinished = step_finished_placeholder;
-    callbacks.componentEnvironment = nullptr;
-
-    if (fmi2_import_create_dllfmu(handle_, fmi2_fmu_kind_cs, &callbacks) != jm_status_success) {
-        const auto msg = fmu->importer()->last_error_message();
-        fmi2_import_free(handle_);
-        throw error(
-            make_error_code(errc::dl_load_error),
-            fmu->importer()->last_error_message());
-    }
 
     const auto rc = fmi2_import_instantiate(
-        handle_,
+        fmilib_handle(),
         instanceName_.c_str(),
         fmi2_cosimulation,
         nullptr, // fmuResourceLocation
         fmi2_false); // visible
     if (rc != jm_status_success) {
-        fmi2_import_destroy_dllfmu(handle_);
-        fmi2_import_free(handle_);
         throw error(
             make_error_code(errc::model_error),
             last_log_record(instanceName_).message);
@@ -311,11 +303,9 @@ slave_instance::slave_instance(
 slave_instance::~slave_instance() noexcept
 {
     if (simStarted_) {
-        fmi2_import_terminate(handle_);
+        fmi2_import_terminate(fmilib_handle());
     }
-    fmi2_import_free_instance(handle_);
-    fmi2_import_destroy_dllfmu(handle_);
-    fmi2_import_free(handle_);
+    fmi2_import_free_instance(fmilib_handle());
 }
 
 
@@ -326,7 +316,7 @@ void slave_instance::setup(
 {
     assert(!setupComplete_);
     const auto rcs = fmi2_import_setup_experiment(
-        handle_,
+        fmilib_handle(),
         relativeTolerance ? fmi2_true : fmi2_false,
         relativeTolerance ? *relativeTolerance : 0.0,
         to_double_time_point(startTime),
@@ -338,7 +328,7 @@ void slave_instance::setup(
             last_log_record(instanceName_).message);
     }
 
-    const auto rce = fmi2_import_enter_initialization_mode(handle_);
+    const auto rce = fmi2_import_enter_initialization_mode(fmilib_handle());
     if (rce != fmi2_status_ok && rce != fmi2_status_warning) {
         throw error(
             make_error_code(errc::model_error),
@@ -353,7 +343,7 @@ void slave_instance::start_simulation()
 {
     assert(setupComplete_);
     assert(!simStarted_);
-    const auto rc = fmi2_import_exit_initialization_mode(handle_);
+    const auto rc = fmi2_import_exit_initialization_mode(fmilib_handle());
     if (rc != fmi2_status_ok && rc != fmi2_status_warning) {
         throw error(
             make_error_code(errc::model_error),
@@ -366,7 +356,7 @@ void slave_instance::start_simulation()
 void slave_instance::end_simulation()
 {
     assert(simStarted_);
-    const auto rc = fmi2_import_terminate(handle_);
+    const auto rc = fmi2_import_terminate(fmilib_handle());
     simStarted_ = false;
     if (rc != fmi2_status_ok && rc != fmi2_status_warning) {
         throw error(
@@ -380,7 +370,7 @@ step_result slave_instance::do_step(time_point currentT, duration deltaT)
 {
     assert(simStarted_);
     const auto rc = fmi2_import_do_step(
-        handle_,
+        fmilib_handle(),
         to_double_time_point(currentT),
         to_double_duration(deltaT, currentT),
         fmi2_true);
@@ -407,7 +397,7 @@ void slave_instance::get_real_variables(
     COSIM_INPUT_CHECK(variables.size() == values.size());
     if (variables.empty()) return;
     const auto status = fmi2_import_get_real(
-        handle_, variables.data(), variables.size(), values.data());
+        fmilib_handle(), variables.data(), variables.size(), values.data());
     if (status != fmi2_status_ok && status != fmi2_status_warning) {
         throw error(
             make_error_code(errc::model_error),
@@ -423,7 +413,7 @@ void slave_instance::get_integer_variables(
     COSIM_INPUT_CHECK(variables.size() == values.size());
     if (variables.empty()) return;
     const auto status = fmi2_import_get_integer(
-        handle_, variables.data(), variables.size(), values.data());
+        fmilib_handle(), variables.data(), variables.size(), values.data());
     if (status != fmi2_status_ok && status != fmi2_status_warning) {
         throw error(
             make_error_code(errc::model_error),
@@ -440,7 +430,7 @@ void slave_instance::get_boolean_variables(
     if (variables.empty()) return;
     std::vector<fmi2_boolean_t> fmiValues(values.size());
     const auto status = fmi2_import_get_boolean(
-        handle_, variables.data(), variables.size(), fmiValues.data());
+        fmilib_handle(), variables.data(), variables.size(), fmiValues.data());
     if (status != fmi2_status_ok && status != fmi2_status_warning) {
         throw error(
             make_error_code(errc::model_error),
@@ -460,7 +450,7 @@ void slave_instance::get_string_variables(
     if (variables.empty()) return;
     std::vector<fmi2_string_t> fmiValues(values.size());
     const auto status = fmi2_import_get_string(
-        handle_, variables.data(), variables.size(), fmiValues.data());
+        fmilib_handle(), variables.data(), variables.size(), fmiValues.data());
     if (status != fmi2_status_ok && status != fmi2_status_warning) {
         throw error(
             make_error_code(errc::model_error),
@@ -480,7 +470,7 @@ void slave_instance::set_real_variables(
     COSIM_INPUT_CHECK(variables.size() == values.size());
     if (variables.empty()) return;
     const auto status = fmi2_import_set_real(
-        handle_, variables.data(), variables.size(), values.data());
+        fmilib_handle(), variables.data(), variables.size(), values.data());
     if (status == fmi2_status_ok || status == fmi2_status_warning) {
         return;
     } else if (status == fmi2_status_discard) {
@@ -500,7 +490,7 @@ void slave_instance::set_integer_variables(
     COSIM_INPUT_CHECK(variables.size() == values.size());
     if (variables.empty()) return;
     const auto status = fmi2_import_set_integer(
-        handle_, variables.data(), variables.size(), values.data());
+        fmilib_handle(), variables.data(), variables.size(), values.data());
     if (status == fmi2_status_ok || status == fmi2_status_warning) {
         return;
     } else if (status == fmi2_status_discard) {
@@ -525,7 +515,7 @@ void slave_instance::set_boolean_variables(
             static_cast<fmi2_boolean_t>(values[i] ? fmi2_true : fmi2_false);
     }
     const auto status = fmi2_import_set_boolean(
-        handle_, variables.data(), variables.size(), fmiValues.data());
+        fmilib_handle(), variables.data(), variables.size(), fmiValues.data());
     if (status == fmi2_status_ok || status == fmi2_status_warning) {
         return;
     } else if (status == fmi2_status_discard) {
@@ -549,7 +539,7 @@ void slave_instance::set_string_variables(
         fmiValues[i] = values[i].c_str();
     }
     const auto status = fmi2_import_set_string(
-        handle_, variables.data(), variables.size(), fmiValues.data());
+        fmilib_handle(), variables.data(), variables.size(), fmiValues.data());
     if (status == fmi2_status_ok || status == fmi2_status_warning) {
         return;
     } else if (status == fmi2_status_discard) {
@@ -570,7 +560,7 @@ std::shared_ptr<v2::fmu> slave_instance::v2_fmu() const
 
 fmi2_import_t* slave_instance::fmilib_handle() const
 {
-    return handle_;
+    return fmu_->fmilib_handle();
 }
 
 

--- a/src/cosim/fmi/v2/fmu.cpp
+++ b/src/cosim/fmi/v2/fmu.cpp
@@ -164,9 +164,8 @@ fmu::fmu(
     callbacks.stepFinished = step_finished_placeholder;
     callbacks.componentEnvironment = nullptr;
 
-    if (fmi2_import_create_dllfmu(fmilib_handle(), fmi2_fmu_kind_cs, &callbacks) != jm_status_success) {
+    if (fmi2_import_create_dllfmu(handle_, fmi2_fmu_kind_cs, &callbacks) != jm_status_success) {
         const auto msg = importer_->last_error_message();
-        fmi2_import_free(fmilib_handle());
         throw error(
             make_error_code(errc::dl_load_error),
             importer_->last_error_message());


### PR DESCRIPTION
Refactor to simplify fmilib interaction.

The old code was parsing the XML n+1 times for each fmu, where n is the number of slaves.
Also removed some needless calls to free et.al., as these are handled by the destructors anyway. 

Moved `createdllfmu` to the fmu itself.