### PR TITLE
Add notices about workaround in FMU loader code

### DIFF
--- a/src/cosim/fmi/v1/fmu.cpp
+++ b/src/cosim/fmi/v1/fmu.cpp
@@ -263,6 +263,11 @@ log_record last_log_record(const std::string& instanceName)
 } // namespace
 
 
+// NOTE: We have to re-parse the model description XML every time we
+// instantiate a new slave because of a shortcoming in FMI Library.
+// (In brief, fmi1_import_create_dllfmu() and fmi1_import_instantiate_slave()
+// both store their results in the fmi1_import_t object created by
+// fmi1_import_parse_xml().)
 slave_instance::slave_instance(
     std::shared_ptr<v1::fmu> fmu,
     std::string_view instanceName)

--- a/src/cosim/fmi/v2/fmu.cpp
+++ b/src/cosim/fmi/v2/fmu.cpp
@@ -263,6 +263,11 @@ log_record last_log_record(const std::string& instanceName)
 } // namespace
 
 
+// NOTE: We have to re-parse the model description XML every time we
+// instantiate a new slave because of a shortcoming in FMI Library.
+// (In brief, fmi2_import_create_dllfmu() and fmi2_import_instantiate()
+// both store their results in the fmi2_import_t object created by
+// fmi2_import_parse_xml().)
 slave_instance::slave_instance(
     std::shared_ptr<v2::fmu> fmu,
     std::string_view instanceName)


### PR DESCRIPTION
As PR #631 showed, it is not obvious why the `fmu` and `slave_instance` classes are implemented the way they are. (Even I, who wrote the code in the first place, had to dig around in the FMI Library sources to remember why...) Here I've added brief explanations for future reference.