### PR TITLE
Remove gcc8 from the workflow

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         build_type: [Debug, Release]
-        compiler_version: [7, 8, 9]
+        compiler_version: [7, 9]
         compiler_libcxx: [libstdc++11]
         option_fmuproxy: ['fmuproxy=True', 'fmuproxy=False']
 


### PR DESCRIPTION
The ubuntu image no longer ships with gcc8.
https://github.com/actions/virtual-environments/commit/475453f2121f3e575d2f23c6ba4aa883f08de702

This PR removes it.