### PR TITLE
Feature/std filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ if(LIBCOSIM_USING_CONAN)
     endif()
 endif()
 
-set(Boost_components date_time fiber filesystem log)
+set(Boost_components date_time fiber log)
 if (LIBCOSIM_BUILD_TESTS)
     list(APPEND Boost_components timer unit_test_framework)
 endif()

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -6,7 +6,7 @@ include(CMakeFindDependencyMacro)
 list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/@LIBCOSIM_CMAKE_INSTALL_DIR@")
 
 find_dependency(MS_GSL REQUIRED)
-find_dependency(Boost REQUIRED COMPONENTS date_time fiber filesystem log)
+find_dependency(Boost REQUIRED COMPONENTS date_time fiber log)
 set(FMILibrary_USE_SHARED_LIB @FMILibrary_USE_SHARED_LIB@)
 find_dependency(FMILibrary REQUIRED)
 find_dependency(LIBZIP REQUIRED)

--- a/include/cosim/file_cache.hpp
+++ b/include/cosim/file_cache.hpp
@@ -9,7 +9,7 @@
 #ifndef COSIM_FILE_CACHE_HPP
 #define COSIM_FILE_CACHE_HPP
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <memory>
 #include <string_view>
@@ -41,7 +41,7 @@ public:
     {
     public:
         /// The filesystem path to the subdirectory.
-        virtual boost::filesystem::path path() const = 0;
+        virtual cosim::filesystem::path path() const = 0;
         virtual ~directory_rw() = default;
     };
 
@@ -50,7 +50,7 @@ public:
     {
     public:
         /// The filesystem path to the subdirectory.
-        virtual boost::filesystem::path path() const = 0;
+        virtual cosim::filesystem::path path() const = 0;
         virtual ~directory_ro() = default;
     };
 
@@ -129,7 +129,7 @@ public:
      *  It is recommended that this directory be managed in its entirety by
      *  `persistent_file_cache`, i.e., that no other files are stored in it.
      */
-    explicit persistent_file_cache(const boost::filesystem::path& cacheRoot);
+    explicit persistent_file_cache(const cosim::filesystem::path& cacheRoot);
 
     persistent_file_cache(const persistent_file_cache&) = delete;
     persistent_file_cache& operator=(const persistent_file_cache&) = delete;

--- a/include/cosim/fmi/importer.hpp
+++ b/include/cosim/fmi/importer.hpp
@@ -11,8 +11,7 @@
 #define COSIM_FMI_IMPORTER_HPP
 
 #include <cosim/file_cache.hpp>
-
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <map>
 #include <memory>
@@ -75,7 +74,7 @@ public:
      *  \returns
      *      An object which represents the imported FMU.
      */
-    std::shared_ptr<fmu> import(const boost::filesystem::path& fmuPath);
+    std::shared_ptr<fmu> import(const cosim::filesystem::path& fmuPath);
 
     /**
      *  Imports and loads an FMU that has already been unpacked.
@@ -90,7 +89,7 @@ public:
      *      An object which represents the imported FMU.
      */
     std::shared_ptr<fmu> import_unpacked(
-        const boost::filesystem::path& unpackedFMUPath);
+        const cosim::filesystem::path& unpackedFMUPath);
 
     /// Returns the last FMI Library error message.
     std::string last_error_message();
@@ -106,7 +105,7 @@ private:
     std::unique_ptr<jm_callbacks> callbacks_;
     std::unique_ptr<fmi_import_context_t, void (*)(fmi_import_context_t*)> handle_;
 
-    std::map<boost::filesystem::path, std::weak_ptr<fmu>> pathCache_;
+    std::map<cosim::filesystem::path, std::weak_ptr<fmu>> pathCache_;
     std::map<std::string, std::weak_ptr<fmu>> guidCache_;
 };
 

--- a/include/cosim/fmi/v1/fmu.hpp
+++ b/include/cosim/fmi/v1/fmu.hpp
@@ -13,10 +13,9 @@
 #include <cosim/file_cache.hpp>
 #include <cosim/fmi/fmu.hpp>
 #include <cosim/fmi/importer.hpp>
+#include <cosim/fs_portability.hpp>
 #include <cosim/model_description.hpp>
 #include <cosim/time.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <memory>
 #include <string>
@@ -94,7 +93,7 @@ public:
         std::string_view instanceName);
 
     /// The path to the directory in which this FMU was unpacked.
-    boost::filesystem::path directory() const;
+    cosim::filesystem::path directory() const;
 
     /// Returns the underlying C API handle (for FMI Library)
     fmi1_import_t* fmilib_handle() const;

--- a/include/cosim/fmi/v2/fmu.hpp
+++ b/include/cosim/fmi/v2/fmu.hpp
@@ -13,10 +13,9 @@
 #include <cosim/file_cache.hpp>
 #include <cosim/fmi/fmu.hpp>
 #include <cosim/fmi/importer.hpp>
+#include <cosim/fs_portability.hpp>
 #include <cosim/model_description.hpp>
 #include <cosim/time.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <memory>
 #include <string>
@@ -94,7 +93,7 @@ public:
         std::string_view instanceName);
 
     /// Returns the path to the directory in which this FMU was unpacked.
-    boost::filesystem::path directory() const;
+    cosim::filesystem::path directory() const;
 
     /// Returns the underlying C API handle (for FMI Library)
     fmi2_import_t* fmilib_handle() const;

--- a/include/cosim/fs_portability.hpp
+++ b/include/cosim/fs_portability.hpp
@@ -17,7 +17,7 @@ namespace filesystem = std::filesystem;
 }
 #else
 #    include <experimental/filesystem>
-namespace proxyfmu
+namespace cosim
 {
 namespace filesystem = std::experimental::filesystem;
 }

--- a/include/cosim/fs_portability.hpp
+++ b/include/cosim/fs_portability.hpp
@@ -1,0 +1,26 @@
+/**
+ *  \file
+ *
+ *  \copyright
+ *      This Source Code Form is subject to the terms of the Mozilla Public
+ *      License, v. 2.0. If a copy of the MPL was not distributed with this
+ *      file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#ifndef LIBCOSIM_FS_PORTABILITY_HPP
+#define LIBCOSIM_FS_PORTABILITY_HPP
+
+#if __has_include(<filesystem>)
+#    include <filesystem>
+namespace cosim
+{
+namespace filesystem = std::filesystem;
+}
+#else
+#    include <experimental/filesystem>
+namespace proxyfmu
+{
+namespace filesystem = std::experimental::filesystem;
+}
+#endif
+
+#endif //LIBCOSIM_FS_PORTABILITY_HPP

--- a/include/cosim/manipulator/scenario_manager.hpp
+++ b/include/cosim/manipulator/scenario_manager.hpp
@@ -12,8 +12,6 @@
 #include <cosim/manipulator/manipulator.hpp>
 #include <cosim/scenario.hpp>
 
-#include <boost/filesystem/path.hpp>
-
 
 namespace cosim
 {
@@ -68,7 +66,7 @@ public:
      *  The time point at which the scenario will start. The scenario's events
      *  will be executed relative to this time point.
      */
-    void load_scenario(const boost::filesystem::path& scenarioFile, time_point currentTime);
+    void load_scenario(const cosim::filesystem::path& scenarioFile, time_point currentTime);
 
     /// Return if a scenario is running.
     bool is_scenario_running();

--- a/include/cosim/observer/file_observer.hpp
+++ b/include/cosim/observer/file_observer.hpp
@@ -10,9 +10,9 @@
 #ifndef COSIM_OBSERVER_FILE_OBSERVER_HPP
 #define COSIM_OBSERVER_FILE_OBSERVER_HPP
 
+#include <cosim/fs_portability.hpp>
 #include <cosim/observer/observer.hpp>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <atomic>
@@ -37,7 +37,7 @@ public:
      *
      * \param logDir the directory where log files will be created.
      */
-    file_observer(const boost::filesystem::path& logDir);
+    file_observer(const cosim::filesystem::path& logDir);
 
     /**
      * Creates an observer which logs selected variable values to file in csv format.
@@ -45,7 +45,7 @@ public:
      * \param logDir the directory where log files will be created.
      * \param configPath the path to an xml file containing the logging configuration.
      */
-    file_observer(const boost::filesystem::path& logDir, const boost::filesystem::path& configPath);
+    file_observer(const cosim::filesystem::path& logDir, const cosim::filesystem::path& configPath);
 
     /**
      * Returns whether the observer is currently recording values.
@@ -91,7 +91,7 @@ public:
         duration lastStepSize,
         time_point currentTime) override;
 
-    boost::filesystem::path get_log_path();
+    cosim::filesystem::path get_log_path();
 
     ~file_observer() override;
 
@@ -109,8 +109,8 @@ private:
     std::unordered_map<simulator_index, std::unique_ptr<slave_value_writer>> valueWriters_;
     std::unordered_map<simulator_index, observable*> simulators_;
     boost::property_tree::ptree ptree_;
-    boost::filesystem::path configPath_;
-    boost::filesystem::path logDir_;
+    cosim::filesystem::path configPath_;
+    cosim::filesystem::path logDir_;
     bool logFromConfig_ = false;
     size_t defaultDecimationFactor_ = 1;
     std::atomic<bool> recording_ = true;

--- a/include/cosim/osp_config_parser.hpp
+++ b/include/cosim/osp_config_parser.hpp
@@ -14,9 +14,6 @@
 #include <cosim/system_structure.hpp>
 #include <cosim/time.hpp>
 
-#include <boost/filesystem/path.hpp>
-
-
 namespace cosim
 {
 
@@ -42,7 +39,7 @@ struct osp_config
  *  Loads an OSP-IS system structure file.
  */
 osp_config load_osp_config(
-    const boost::filesystem::path& configPath,
+    const cosim::filesystem::path& configPath,
     cosim::model_uri_resolver& resolver);
 
 

--- a/include/cosim/scenario_parser.hpp
+++ b/include/cosim/scenario_parser.hpp
@@ -12,8 +12,6 @@
 #include <cosim/algorithm.hpp>
 #include <cosim/scenario.hpp>
 
-#include <boost/filesystem/path.hpp>
-
 namespace cosim
 {
 /**
@@ -26,7 +24,7 @@ namespace cosim
  *  A map containing the simulators currently loaded in the execution.
  */
 scenario::scenario parse_scenario(
-    const boost::filesystem::path& scenarioFile,
+    const cosim::filesystem::path& scenarioFile,
     const std::unordered_map<simulator_index, manipulable*>& simulators);
 } // namespace cosim
 

--- a/include/cosim/ssp/ssp_loader.hpp
+++ b/include/cosim/ssp/ssp_loader.hpp
@@ -14,8 +14,6 @@
 #include <cosim/system_structure.hpp>
 #include <cosim/time.hpp>
 
-#include <boost/filesystem/path.hpp>
-
 #include <memory>
 #include <optional>
 #include <string>
@@ -78,7 +76,7 @@ public:
      *  \param [in] configPath
      *      Path to the .ssp archive, or a directory holding one or more .ssd files.
      */
-    ssp_configuration load(const boost::filesystem::path& configPath);
+    ssp_configuration load(const cosim::filesystem::path& configPath);
 
 private:
     std::optional<std::string> ssdFileName_;

--- a/include/cosim/uri.hpp
+++ b/include/cosim/uri.hpp
@@ -10,7 +10,7 @@
 #ifndef COSIM_URI_HPP
 #define COSIM_URI_HPP
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <cstddef>
 #include <optional>
@@ -258,7 +258,7 @@ uri percent_encode_uri(
  *      `file:///<os-dependent path>`, except when `path` is empty, in which
  *      case the function returns `file:`.
  */
-uri path_to_file_uri(const boost::filesystem::path& path);
+uri path_to_file_uri(const cosim::filesystem::path& path);
 
 
 /**
@@ -271,7 +271,7 @@ uri path_to_file_uri(const boost::filesystem::path& path);
  *  \returns
  *      The path that corresponds to `fileUri`.
  */
-boost::filesystem::path file_uri_to_path(const uri& fileUri);
+cosim::filesystem::path file_uri_to_path(const uri& fileUri);
 
 
 } // namespace cosim

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(publicHeaders
     "cosim/fmi/importer.hpp"
     "cosim/fmi/v1/fmu.hpp"
     "cosim/fmi/v2/fmu.hpp"
+    "cosim/fs_portability.hpp"
     "cosim/function/description.hpp"
     "cosim/function/function.hpp"
     "cosim/function/linear_transformation.hpp"
@@ -200,7 +201,6 @@ target_link_libraries(cosim
         Boost::boost
         Boost::date_time
         Boost::fiber
-        Boost::filesystem
         Boost::log
         gsl
     PRIVATE
@@ -219,7 +219,7 @@ if(LIBCOSIM_WITH_FMUPROXY)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_libraries(cosim INTERFACE "atomic")
+    target_link_libraries(cosim INTERFACE "atomic" "stdc++fs")
 endif()
 if(WIN32)
     if(BUILD_SHARED_LIBS)

--- a/src/cosim/fmi/importer.cpp
+++ b/src/cosim/fmi/importer.cpp
@@ -108,7 +108,7 @@ struct minimal_model_description
 
 // Reads the 'fmiVersion' and 'guid' attributes from the XML file.
 minimal_model_description peek_model_description(
-    const boost::filesystem::path& fmuUnpackDir)
+    const cosim::filesystem::path& fmuUnpackDir)
 {
     const auto xmlFile = fmuUnpackDir / "modelDescription.xml";
     boost::property_tree::ptree xml;
@@ -148,17 +148,17 @@ minimal_model_description peek_model_description(
 }
 
 bool is_outdated(
-    const boost::filesystem::path& file,
-    const boost::filesystem::path& comparator)
+    const cosim::filesystem::path& file,
+    const cosim::filesystem::path& comparator)
 {
-    return !boost::filesystem::exists(file) ||
-        boost::filesystem::last_write_time(comparator) > boost::filesystem::last_write_time(file);
+    return !cosim::filesystem::exists(file) ||
+        cosim::filesystem::last_write_time(comparator) > cosim::filesystem::last_write_time(file);
 }
 
 } // namespace
 
 
-std::shared_ptr<fmu> importer::import(const boost::filesystem::path& fmuPath)
+std::shared_ptr<fmu> importer::import(const cosim::filesystem::path& fmuPath)
 {
     prune_ptr_caches();
     auto pit = pathCache_.find(fmuPath);
@@ -203,8 +203,8 @@ std::shared_ptr<fmu> importer::import(const boost::filesystem::path& fmuPath)
         } catch (...) {
             // Remove model description again, so we don't erroneously think
             // that the unpacking was successful the next time we try it.
-            boost::system::error_code ignoredError;
-            boost::filesystem::remove(modelDescriptionPath, ignoredError);
+            std::error_code ignoredError;
+            cosim::filesystem::remove(modelDescriptionPath, ignoredError);
             throw;
         }
     }
@@ -228,20 +228,20 @@ namespace
 class existing_directory_ro : public file_cache::directory_ro
 {
 public:
-    explicit existing_directory_ro(const boost::filesystem::path& path)
+    explicit existing_directory_ro(const cosim::filesystem::path& path)
         : path_(path)
     { }
 
-    boost::filesystem::path path() const override { return path_; }
+    cosim::filesystem::path path() const override { return path_; }
 
 private:
-    boost::filesystem::path path_;
+    cosim::filesystem::path path_;
 };
 } // namespace
 
 
 std::shared_ptr<fmu> importer::import_unpacked(
-    const boost::filesystem::path& unpackedFMUPath)
+    const cosim::filesystem::path& unpackedFMUPath)
 {
     prune_ptr_caches();
     const auto minModelDesc = peek_model_description(unpackedFMUPath);

--- a/src/cosim/fmi/v1/fmu.cpp
+++ b/src/cosim/fmi/v1/fmu.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<v1::slave_instance> fmu::instantiate_v1_slave(
 }
 
 
-boost::filesystem::path fmu::directory() const
+cosim::filesystem::path fmu::directory() const
 {
     return dir_->path();
 }

--- a/src/cosim/fmi/v2/fmu.cpp
+++ b/src/cosim/fmi/v2/fmu.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<v2::slave_instance> fmu::instantiate_v2_slave(
 }
 
 
-boost::filesystem::path fmu::directory() const
+cosim::filesystem::path fmu::directory() const
 {
     return dir_->path();
 }

--- a/src/cosim/fmi/windows.cpp
+++ b/src/cosim/fmi/windows.cpp
@@ -27,7 +27,7 @@ std::mutex path_env_var_mutex;
 } // namespace
 
 
-detail::additional_path::additional_path(const boost::filesystem::path& p)
+detail::additional_path::additional_path(const cosim::filesystem::path& p)
 {
     std::lock_guard<std::mutex> lock(path_env_var_mutex);
 
@@ -67,7 +67,7 @@ detail::additional_path::~additional_path()
 }
 
 
-boost::filesystem::path fmu_binaries_dir(const boost::filesystem::path& baseDir)
+cosim::filesystem::path fmu_binaries_dir(const cosim::filesystem::path& baseDir)
 {
 #    ifdef _WIN64
     const auto platformSubdir = L"win64";

--- a/src/cosim/fmi/windows.hpp
+++ b/src/cosim/fmi/windows.hpp
@@ -11,7 +11,7 @@
 #define COSIM_FMI_WINDOWS_HPP
 #ifdef _WIN32
 
-#    include <boost/filesystem.hpp>
+#    include <cosim/fs_portability.hpp>
 
 #    include <string>
 
@@ -50,7 +50,7 @@ class additional_path
 {
 public:
     /// Constructor. Adds `p` to `PATH`.
-    additional_path(const boost::filesystem::path& p);
+    additional_path(const cosim::filesystem::path& p);
 
     /// Destructor.  Removes the path from `PATH` again.
     ~additional_path();
@@ -64,7 +64,7 @@ private:
 
 
 /// Given `path/to/fmu`, returns `path/to/fmu/binaries/<platform>`
-boost::filesystem::path fmu_binaries_dir(const boost::filesystem::path& baseDir);
+cosim::filesystem::path fmu_binaries_dir(const cosim::filesystem::path& baseDir);
 
 
 } // namespace fmi

--- a/src/cosim/fmuproxy/fmuproxy_client.cpp
+++ b/src/cosim/fmuproxy/fmuproxy_client.cpp
@@ -6,9 +6,8 @@
 #include <cosim/error.hpp>
 #include <cosim/fmuproxy/fmuproxy_client.hpp>
 #include <cosim/fmuproxy/thrift_state.hpp>
+#include <cosim/fs_portability.hpp>
 #include <cosim/log/logger.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <cstdio>
 #include <string>
@@ -30,7 +29,7 @@ using namespace fmuproxy::thrift;
 using namespace apache::thrift::transport;
 using namespace apache::thrift::protocol;
 
-namespace fs = boost::filesystem;
+namespace fs = cosim::filesystem;
 
 namespace
 {

--- a/src/cosim/manipulator/scenario_manager.cpp
+++ b/src/cosim/manipulator/scenario_manager.cpp
@@ -43,7 +43,7 @@ public:
         BOOST_LOG_SEV(log::logger(), log::info) << "Successfully loaded scenario";
     }
 
-    void load_scenario(const boost::filesystem::path& scenarioFile, time_point currentTime)
+    void load_scenario(const cosim::filesystem::path& scenarioFile, time_point currentTime)
     {
         BOOST_LOG_SEV(log::logger(), log::info) << "Loading scenario from " << scenarioFile;
         auto scenario = parse_scenario(scenarioFile, simulators_);
@@ -240,7 +240,7 @@ void scenario_manager::load_scenario(
 }
 
 void scenario_manager::load_scenario(
-    const boost::filesystem::path& scenarioFile,
+    const cosim::filesystem::path& scenarioFile,
     time_point currentTime)
 {
     pimpl_->load_scenario(scenarioFile, currentTime);

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -9,12 +9,11 @@
 #include "cosim/log/logger.hpp"
 
 #include <boost/date_time/local_time/local_time.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
 #include <algorithm>
 #include <codecvt>
+#include <fstream>
 #include <locale>
 #include <map>
 #include <mutex>
@@ -38,9 +37,9 @@ std::string format_time(boost::posix_time::ptime now)
     return converter.to_bytes(wss.str());
 }
 
-void clear_file_contents_if_exists(const boost::filesystem::path& filePath, boost::filesystem::ofstream& fsw)
+void clear_file_contents_if_exists(const cosim::filesystem::path& filePath, std::ofstream& fsw)
 {
-    if (boost::filesystem::exists(filePath)) {
+    if (cosim::filesystem::exists(filePath)) {
         //clear file contents
         fsw.open(filePath, std::ios_base::out | std::ios_base::trunc);
         fsw.close();
@@ -52,7 +51,7 @@ void clear_file_contents_if_exists(const boost::filesystem::path& filePath, boos
 class file_observer::slave_value_writer
 {
 public:
-    slave_value_writer(observable* observable, boost::filesystem::path& logDir, bool timeStampedFileNames = true)
+    slave_value_writer(observable* observable, cosim::filesystem::path& logDir, bool timeStampedFileNames = true)
         : observable_(observable)
         , logDir_(logDir)
         , timeStampedFileNames_(timeStampedFileNames)
@@ -60,7 +59,7 @@ public:
         initialize_default();
     }
 
-    slave_value_writer(observable* observable, boost::filesystem::path& logDir, size_t decimationFactor,
+    slave_value_writer(observable* observable, cosim::filesystem::path& logDir, size_t decimationFactor,
         const std::vector<variable_description>& variables, bool timeStampedFileNames = true)
         : observable_(observable)
         , logDir_(logDir)
@@ -199,7 +198,7 @@ private:
         }
 
         const auto filePath = logDir_ / filename;
-        boost::filesystem::create_directories(logDir_);
+        cosim::filesystem::create_directories(logDir_);
         fsw_.open(filePath, std::ios_base::out | std::ios_base::app);
 
         if (fsw_.fail()) {
@@ -265,23 +264,23 @@ private:
     std::vector<variable_description> boolVars_;
     std::vector<variable_description> stringVars_;
     observable* observable_;
-    boost::filesystem::path logDir_;
+    cosim::filesystem::path logDir_;
     size_t decimationFactor_ = 1;
-    boost::filesystem::ofstream fsw_;
+    std::ofstream fsw_;
     std::stringstream ss_;
     std::atomic<bool> recording_ = true;
     std::mutex mutex_;
     bool timeStampedFileNames_ = true;
 };
 
-file_observer::file_observer(const boost::filesystem::path& logDir)
-    : logDir_(boost::filesystem::absolute(logDir))
+file_observer::file_observer(const cosim::filesystem::path& logDir)
+    : logDir_(cosim::filesystem::absolute(logDir))
 {
 }
 
-file_observer::file_observer(const boost::filesystem::path& logDir, const boost::filesystem::path& configPath)
+file_observer::file_observer(const cosim::filesystem::path& logDir, const cosim::filesystem::path& configPath)
     : configPath_(configPath)
-    , logDir_(boost::filesystem::absolute(logDir))
+    , logDir_(cosim::filesystem::absolute(logDir))
     , logFromConfig_(true)
 {
     boost::property_tree::read_xml(configPath_.string(), ptree_,
@@ -369,7 +368,7 @@ void file_observer::simulator_step_complete(simulator_index index, step_number l
     }
 }
 
-boost::filesystem::path file_observer::get_log_path()
+cosim::filesystem::path file_observer::get_log_path()
 {
     return logDir_;
 }

--- a/src/cosim/osp_config_parser.cpp
+++ b/src/cosim/osp_config_parser.cpp
@@ -79,13 +79,18 @@ private:
 // The following class was copied from Microsoft Guidelines Support Library
 // https://github.com/microsoft/GSL
 // final_action allows you to ensure something gets run at the end of a scope
-template <class F>
+template<class F>
 class final_action
 {
 public:
-    explicit final_action(F f) noexcept : f_(std::move(f)) {}
+    explicit final_action(F f) noexcept
+        : f_(std::move(f))
+    { }
 
-    final_action(final_action&& other) noexcept : f_(std::move(other.f_)), invoke_(std::exchange(other.invoke_, false)) {}
+    final_action(final_action&& other) noexcept
+        : f_(std::move(other.f_))
+        , invoke_(std::exchange(other.invoke_, false))
+    { }
 
     final_action(const final_action&) = delete;
     final_action& operator=(const final_action&) = delete;
@@ -106,7 +111,7 @@ class osp_config_parser
 
 public:
     osp_config_parser(
-        const boost::filesystem::path& configPath);
+        const cosim::filesystem::path& configPath);
     ~osp_config_parser() noexcept;
 
     struct SimulationInformation
@@ -250,7 +255,7 @@ T attribute_or(xercesc::DOMElement* el, const char* attributeName, T defaultValu
 } // namespace
 
 osp_config_parser::osp_config_parser(
-    const boost::filesystem::path& configPath)
+    const cosim::filesystem::path& configPath)
 {
     // Root node
     xercesc::XMLPlatformUtils::Initialize();
@@ -595,7 +600,7 @@ struct variable_group_description
 
 struct extended_model_description
 {
-    explicit extended_model_description(const boost::filesystem::path& ospModelDescription)
+    explicit extended_model_description(const cosim::filesystem::path& ospModelDescription)
     {
         xercesc::XMLPlatformUtils::Initialize();
         const auto xerces_cleanup = final_action([]() {
@@ -888,11 +893,11 @@ void connect_vector_sum_functions(
 } // namespace
 
 osp_config load_osp_config(
-    const boost::filesystem::path& configPath,
+    const cosim::filesystem::path& configPath,
     model_uri_resolver& resolver)
 {
-    const auto absolutePath = boost::filesystem::absolute(configPath);
-    const auto configFile = boost::filesystem::is_regular_file(absolutePath)
+    const auto absolutePath = cosim::filesystem::absolute(configPath);
+    const auto configFile = cosim::filesystem::is_regular_file(absolutePath)
         ? absolutePath
         : absolutePath / "OspSystemStructure.xml";
     const auto baseURI = path_to_file_uri(configFile);
@@ -931,15 +936,15 @@ osp_config load_osp_config(
 
         std::string msmiFileName = model->description()->name + "_OspModelDescription.xml";
         const auto modelUri = resolve_reference(baseURI, simulator.source);
-        boost::filesystem::path msmiFilePath;
+        cosim::filesystem::path msmiFilePath;
 
         if (modelUri.scheme() == "file") {
-            msmiFilePath = file_uri_to_path(modelUri).remove_leaf() / msmiFileName;
-            if (boost::filesystem::exists(msmiFilePath)) {
+            msmiFilePath = file_uri_to_path(modelUri).remove_filename() / msmiFileName;
+            if (cosim::filesystem::exists(msmiFilePath)) {
                 emds.emplace(simulator.name, msmiFilePath);
             } else {
                 msmiFilePath = configFile.parent_path() / msmiFileName;
-                if (boost::filesystem::exists(msmiFilePath)) {
+                if (cosim::filesystem::exists(msmiFilePath)) {
                     emds.emplace(simulator.name, msmiFilePath);
                 }
             }
@@ -947,7 +952,7 @@ osp_config load_osp_config(
             // Makes it possible to keep OspModelDescription at configuration path
             // even when there are FMUs with other URI than file (fmu-proxy).
             msmiFilePath = configFile.parent_path() / msmiFileName;
-            if (boost::filesystem::exists(msmiFilePath)) {
+            if (cosim::filesystem::exists(msmiFilePath)) {
                 emds.emplace(simulator.name, msmiFilePath);
             }
         }

--- a/src/cosim/scenario_parser.cpp
+++ b/src/cosim/scenario_parser.cpp
@@ -5,9 +5,8 @@
  */
 #include "cosim/scenario_parser.hpp"
 
-#include <boost/filesystem/fstream.hpp>
-
 #include <cstdlib>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <optional>
@@ -192,11 +191,11 @@ std::optional<cosim::time_point> parse_end_time(const YAML::Node& j)
 
 
 scenario::scenario parse_scenario(
-    const boost::filesystem::path& scenarioFile,
+    const cosim::filesystem::path& scenarioFile,
     const std::unordered_map<simulator_index,
         manipulable*>& simulators)
 {
-    boost::filesystem::ifstream i(scenarioFile);
+    std::ifstream i(scenarioFile);
     if (!i) {
         std::ostringstream oss;
         oss << "Cannot load scenario. Failed to open file " << scenarioFile;

--- a/src/cosim/ssp/ssp_loader.cpp
+++ b/src/cosim/ssp/ssp_loader.cpp
@@ -68,7 +68,7 @@ void add_parameter_set(
 }
 } // namespace
 
-ssp_configuration ssp_loader::load(const boost::filesystem::path& configPath)
+ssp_configuration ssp_loader::load(const cosim::filesystem::path& configPath)
 {
     auto sspFile = configPath;
     std::optional<cosim::utility::temp_dir> temp_ssp_dir;
@@ -80,8 +80,8 @@ ssp_configuration ssp_loader::load(const boost::filesystem::path& configPath)
     }
 
     const auto ssdFileName = ssdFileName_ ? *ssdFileName_ : "SystemStructure";
-    const auto absolutePath = boost::filesystem::absolute(sspFile);
-    const auto configFile = boost::filesystem::is_regular_file(absolutePath)
+    const auto absolutePath = cosim::filesystem::absolute(sspFile);
+    const auto configFile = cosim::filesystem::is_regular_file(absolutePath)
         ? absolutePath
         : absolutePath / std::string(ssdFileName + ".ssd");
     const auto baseURI = path_to_file_uri(configFile);

--- a/src/cosim/ssp/ssp_parser.cpp
+++ b/src/cosim/ssp/ssp_parser.cpp
@@ -7,7 +7,6 @@
 
 #include "cosim/error.hpp"
 
-#include <boost/filesystem/operations.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
 namespace cosim
@@ -97,7 +96,7 @@ inline ssp_parser::Connector check_connector(const std::string& name, ssp_parser
 
 } // namespace
 
-ssp_parser::ssp_parser(const boost::filesystem::path& ssdPath)
+ssp_parser::ssp_parser(const cosim::filesystem::path& ssdPath)
 {
     boost::property_tree::ptree root;
     boost::property_tree::read_xml(ssdPath.string(), root,
@@ -154,8 +153,8 @@ ssp_parser::ssp_parser(const boost::filesystem::path& ssdPath)
             for (const auto& parameterBinding : *parameterBindings) {
                 if (const auto& source = get_optional_attribute<std::string>(parameterBinding.second, "source")) {
                     boost::property_tree::ptree binding;
-                    boost::filesystem::path ssvPath = ssdPath.parent_path() / *source;
-                    if (!boost::filesystem::exists(ssvPath)) {
+                    cosim::filesystem::path ssvPath = ssdPath.parent_path() / *source;
+                    if (!cosim::filesystem::exists(ssvPath)) {
                         std::ostringstream oss;
                         oss << "File '" << ssvPath << "' does not exists!";
                         throw std::runtime_error(oss.str());

--- a/src/cosim/ssp/ssp_parser.hpp
+++ b/src/cosim/ssp/ssp_parser.hpp
@@ -11,7 +11,6 @@
 
 #include "cosim/algorithm.hpp"
 
-#include <boost/filesystem/path.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <optional>
@@ -25,7 +24,7 @@ class ssp_parser
 {
 
 public:
-    explicit ssp_parser(const boost::filesystem::path& xmlPath);
+    explicit ssp_parser(const cosim::filesystem::path& xmlPath);
     ~ssp_parser() noexcept;
 
     struct DefaultExperiment

--- a/src/cosim/uri.cpp
+++ b/src/cosim/uri.cpp
@@ -490,7 +490,7 @@ uri percent_encode_uri(
 }
 
 
-uri path_to_file_uri(const boost::filesystem::path& path)
+uri path_to_file_uri(const cosim::filesystem::path& path)
 {
     COSIM_INPUT_CHECK(path.empty() || path.has_root_directory());
 
@@ -526,7 +526,7 @@ uri path_to_file_uri(const boost::filesystem::path& path)
 }
 
 
-boost::filesystem::path file_uri_to_path(const uri& fileUri)
+cosim::filesystem::path file_uri_to_path(const uri& fileUri)
 {
     COSIM_INPUT_CHECK(fileUri.scheme() && *fileUri.scheme() == "file");
     COSIM_INPUT_CHECK(fileUri.authority() &&
@@ -551,10 +551,10 @@ boost::filesystem::path file_uri_to_path(const uri& fileUri)
     if (rc != S_OK) {
         throw std::system_error(rc, std::system_category());
     }
-    return boost::filesystem::path(pathBuffer, pathBuffer + pathSize);
+    return cosim::filesystem::path(pathBuffer, pathBuffer + pathSize);
 
 #else
-    return boost::filesystem::path(percent_decode(fileUri.path()));
+    return cosim::filesystem::path(percent_decode(fileUri.path()));
 #endif
 }
 

--- a/src/cosim/utility/concurrency.cpp
+++ b/src/cosim/utility/concurrency.cpp
@@ -95,7 +95,7 @@ void shared_mutex::unlock_shared()
 
 
 file_lock::file_lock(
-    const boost::filesystem::path& path,
+    const cosim::filesystem::path& path,
     file_lock_initial_state initialState)
     : fileMutex_(get_file_mutex(path))
 {
@@ -173,7 +173,7 @@ void file_lock::unlock_shared()
 }
 
 
-file_lock::boost_wrapper::boost_wrapper(const boost::filesystem::path& path)
+file_lock::boost_wrapper::boost_wrapper(const cosim::filesystem::path& path)
 {
 #ifdef _WIN32
     // NOTE: The share mode flags must match those used by boost::interprocess.
@@ -293,17 +293,17 @@ void file_lock::boost_wrapper::unlock_shared()
 }
 
 
-file_lock::file_mutex::file_mutex(const boost::filesystem::path& path)
+file_lock::file_mutex::file_mutex(const cosim::filesystem::path& path)
     : file(path)
 { }
 
 
 std::shared_ptr<file_lock::file_mutex> file_lock::get_file_mutex(
-    const boost::filesystem::path& path)
+    const cosim::filesystem::path& path)
 {
     struct file_mutex_cache_entry
     {
-        boost::filesystem::path path;
+        cosim::filesystem::path path;
         std::weak_ptr<file_mutex> fileMutex;
     };
     static std::vector<file_mutex_cache_entry> fileMutexCache;
@@ -315,7 +315,7 @@ std::shared_ptr<file_lock::file_mutex> file_lock::get_file_mutex(
     std::lock_guard<decltype(cacheMutex)> guard(cacheMutex);
     for (auto it = fileMutexCache.begin(); it != fileMutexCache.end();) {
         if (auto fm = it->fileMutex.lock()) {
-            if (boost::filesystem::equivalent(path, it->path)) {
+            if (cosim::filesystem::equivalent(path, it->path)) {
                 assert(!fileMutex);
                 fileMutex = std::move(fm);
             }
@@ -328,7 +328,7 @@ std::shared_ptr<file_lock::file_mutex> file_lock::get_file_mutex(
     // If no element corresponding to the given path was found, create one.
     if (!fileMutex) {
         fileMutex = std::make_shared<file_mutex>(path);
-        fileMutexCache.push_back({boost::filesystem::canonical(path), fileMutex});
+        fileMutexCache.push_back({cosim::filesystem::canonical(path), fileMutex});
     }
 
     return fileMutex;

--- a/src/cosim/utility/concurrency.hpp
+++ b/src/cosim/utility/concurrency.hpp
@@ -10,9 +10,10 @@
 #ifndef COSIM_UTILITY_CONCURRENCY
 #define COSIM_UTILITY_CONCURRENCY
 
+#include <cosim/fs_portability.hpp>
+
 #include <boost/fiber/condition_variable.hpp>
 #include <boost/fiber/mutex.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 
 #include <memory>
@@ -196,7 +197,7 @@ public:
      *  If it does not exist, it will be created.
      *
      *  Two different paths `p1` and `p2` are considered to refer to the
-     *  same file if `boost::filesystem::equivalent(p1,p2)` is `true`.
+     *  same file if `cosim::filesystem::equivalent(p1,p2)` is `true`.
      *
      *  \param [in] path
      *      The path to the lock file.
@@ -208,7 +209,7 @@ public:
      *      if the file could not be opened or created.
      */
     explicit file_lock(
-        const boost::filesystem::path& path,
+        const cosim::filesystem::path& path,
         file_lock_initial_state initialState = file_lock_initial_state::not_locked);
 
     /**
@@ -280,7 +281,7 @@ private:
     class boost_wrapper
     {
     public:
-        explicit boost_wrapper(const boost::filesystem::path& path);
+        explicit boost_wrapper(const cosim::filesystem::path& path);
         void lock();
         bool try_lock();
         void unlock();
@@ -297,14 +298,14 @@ private:
     // Holds the mutex and file lock associated with a particular file.
     struct file_mutex
     {
-        file_mutex(const boost::filesystem::path& path);
+        file_mutex(const cosim::filesystem::path& path);
         shared_mutex mutex;
         boost_wrapper file;
     };
 
     // Returns the mutex and file lock associated with the file at `path`.
     static std::shared_ptr<file_mutex> get_file_mutex(
-        const boost::filesystem::path& path);
+        const cosim::filesystem::path& path);
 
     // The mutex and file lock associated with this object.
     std::shared_ptr<file_mutex> fileMutex_;

--- a/src/cosim/utility/filesystem.cpp
+++ b/src/cosim/utility/filesystem.cpp
@@ -17,16 +17,16 @@ namespace utility
 {
 
 
-temp_dir::temp_dir(const boost::filesystem::path& parent)
+temp_dir::temp_dir(const cosim::filesystem::path& parent)
 {
     if (parent.empty()) {
-        path_ = boost::filesystem::temp_directory_path() / ("libcosim_" + random_uuid());
+        path_ = cosim::filesystem::temp_directory_path() / ("libcosim_" + random_uuid());
     } else if (parent.is_absolute()) {
         path_ = parent / random_uuid();
     } else {
-        path_ = boost::filesystem::temp_directory_path() / parent / random_uuid();
+        path_ = cosim::filesystem::temp_directory_path() / parent / random_uuid();
     }
-    boost::filesystem::create_directories(path_);
+    cosim::filesystem::create_directories(path_);
 }
 
 temp_dir::temp_dir(temp_dir&& other) noexcept
@@ -48,7 +48,7 @@ temp_dir::~temp_dir()
     delete_noexcept();
 }
 
-const boost::filesystem::path& temp_dir::path() const
+const cosim::filesystem::path& temp_dir::path() const
 {
     return path_;
 }
@@ -56,8 +56,8 @@ const boost::filesystem::path& temp_dir::path() const
 void temp_dir::delete_noexcept() noexcept
 {
     if (!path_.empty()) {
-        boost::system::error_code errorCode;
-        boost::filesystem::remove_all(path_, errorCode);
+        std::error_code errorCode;
+        cosim::filesystem::remove_all(path_, errorCode);
         path_.clear();
     }
 }

--- a/src/cosim/utility/filesystem.hpp
+++ b/src/cosim/utility/filesystem.hpp
@@ -10,7 +10,7 @@
 #ifndef COSIM_UTILITY_FILESYSTEM_HPP
 #define COSIM_UTILITY_FILESYSTEM_HPP
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 
 namespace cosim
@@ -41,7 +41,7 @@ public:
      *    - If `parent` is absolute: `parent/name`
     */
     explicit temp_dir(
-        const boost::filesystem::path& parent = boost::filesystem::path());
+        const cosim::filesystem::path& parent = cosim::filesystem::path());
 
     temp_dir(const temp_dir&) = delete;
     temp_dir& operator=(const temp_dir&) = delete;
@@ -63,12 +63,12 @@ public:
     ~temp_dir() noexcept;
 
     /// Returns the path to the directory.
-    const boost::filesystem::path& path() const;
+    const cosim::filesystem::path& path() const;
 
 private:
     void delete_noexcept() noexcept;
 
-    boost::filesystem::path path_;
+    cosim::filesystem::path path_;
 };
 
 

--- a/src/cosim/utility/zip.cpp
+++ b/src/cosim/utility/zip.cpp
@@ -72,7 +72,7 @@ archive::archive() noexcept
 }
 
 
-archive::archive(const boost::filesystem::path& path)
+archive::archive(const cosim::filesystem::path& path)
     : m_archive{nullptr}
 {
     open(path);
@@ -101,7 +101,7 @@ archive::~archive() noexcept
 }
 
 
-void archive::open(const boost::filesystem::path& path)
+void archive::open(const cosim::filesystem::path& path)
 {
     assert(!is_open());
     int errorCode;
@@ -208,7 +208,7 @@ void copy_to_stream(
 void extract_file_as(
     ::zip* archive,
     entry_index index,
-    const boost::filesystem::path& targetPath,
+    const cosim::filesystem::path& targetPath,
     std::vector<char>& buffer)
 {
     assert(archive != nullptr);
@@ -236,11 +236,11 @@ void extract_file_as(
 
 
 void archive::extract_all(
-    const boost::filesystem::path& targetDir) const
+    const cosim::filesystem::path& targetDir) const
 {
     assert(is_open());
-    if (!boost::filesystem::exists(targetDir) ||
-        !boost::filesystem::is_directory(targetDir)) {
+    if (!cosim::filesystem::exists(targetDir) ||
+        !cosim::filesystem::is_directory(targetDir)) {
         throw std::system_error(
             make_error_code(std::errc::not_a_directory),
             targetDir.string());
@@ -251,16 +251,16 @@ void archive::extract_all(
     for (entry_index index = 0; index < entryCount; ++index) {
         const auto entryName = entry_name(index);
         if (!entryName.empty()) {
-            const auto entryPath = boost::filesystem::path(entryName);
+            const auto entryPath = cosim::filesystem::path(entryName);
             if (entryPath.has_root_path()) {
                 throw error(
                     "Archive contains an entry with an absolute path: " + entryName);
             }
             const auto targetPath = targetDir / entryPath;
             if (entryName.back() == '/') {
-                boost::filesystem::create_directories(targetPath);
+                cosim::filesystem::create_directories(targetPath);
             } else {
-                boost::filesystem::create_directories(targetPath.parent_path());
+                cosim::filesystem::create_directories(targetPath.parent_path());
                 extract_file_as(m_archive, index, targetPath, buffer);
             }
         }
@@ -268,12 +268,12 @@ void archive::extract_all(
 }
 
 
-boost::filesystem::path archive::extract_file_to(
+cosim::filesystem::path archive::extract_file_to(
     entry_index index,
-    const boost::filesystem::path& targetDir) const
+    const cosim::filesystem::path& targetDir) const
 {
     assert(is_open());
-    const auto entryPath = boost::filesystem::path(entry_name(index));
+    const auto entryPath = cosim::filesystem::path(entry_name(index));
     const auto targetPath = targetDir / entryPath.filename();
     auto buffer = std::vector<char>(4096 * 16);
     extract_file_as(m_archive, index, targetPath, buffer);

--- a/src/cosim/utility/zip.hpp
+++ b/src/cosim/utility/zip.hpp
@@ -11,8 +11,7 @@
 #define COSIM_UTILITY_ZIP_HPP
 
 #include <cosim/exception.hpp>
-
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <cstdint>
 #include <string>
@@ -83,7 +82,7 @@ public:
      *  \throws cosim::utility::zip::error
      *      If there was an error opening the archive.
      */
-    explicit archive(const boost::filesystem::path& path);
+    explicit archive(const cosim::filesystem::path& path);
 
     // Disable copying.
     archive(const archive&) = delete;
@@ -107,7 +106,7 @@ public:
      *  \pre
      *      `is_open() == false`
      */
-    void open(const boost::filesystem::path& path);
+    void open(const cosim::filesystem::path& path);
 
     /**
      *  Closes the archive.
@@ -190,7 +189,7 @@ public:
      *  \pre
      *      `is_open() == true`
      */
-    void extract_all(const boost::filesystem::path& targetDir) const;
+    void extract_all(const cosim::filesystem::path& targetDir) const;
 
     /**
      *  Extracts a single file from the archive, placing it in a specific
@@ -214,9 +213,9 @@ public:
      *  \pre
      *      `is_open() == true`
      */
-    boost::filesystem::path extract_file_to(
+    cosim::filesystem::path extract_file_to(
         entry_index index,
-        const boost::filesystem::path& targetDir) const;
+        const cosim::filesystem::path& targetDir) const;
 
 private:
     ::zip* m_archive;

--- a/tests/file_observer_dynamic_logging_test.cpp
+++ b/tests/file_observer_dynamic_logging_test.cpp
@@ -6,7 +6,7 @@
 #include <cosim/log/simple.hpp>
 #include <cosim/observer/file_observer.hpp>
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <exception>
 #include <memory>
@@ -17,18 +17,18 @@
 #define REQUIRE(test) \
     if (!(test)) throw std::runtime_error("Requirement not satisfied: " #test)
 
-int64_t filecount(const boost::filesystem::path& path)
+int64_t filecount(const cosim::filesystem::path& path)
 {
     return std::count_if(
-        boost::filesystem::directory_iterator(path),
-        boost::filesystem::directory_iterator(),
-        static_cast<bool (*)(const boost::filesystem::path&)>(boost::filesystem::is_regular_file));
+        cosim::filesystem::directory_iterator(path),
+        cosim::filesystem::directory_iterator(),
+        static_cast<bool (*)(const cosim::filesystem::path&)>(cosim::filesystem::is_regular_file));
 }
 
-void remove_directory_contents(const boost::filesystem::path& path)
+void remove_directory_contents(const cosim::filesystem::path& path)
 {
-    for (boost::filesystem::directory_iterator end_dir_it, it(path); it != end_dir_it; ++it) {
-        boost::filesystem::remove_all(it->path());
+    for (cosim::filesystem::directory_iterator end_dir_it, it(path); it != end_dir_it; ++it) {
+        cosim::filesystem::remove_all(it->path());
     }
 }
 
@@ -41,9 +41,9 @@ int main()
         constexpr cosim::time_point startTime = cosim::to_time_point(0.0);
         constexpr cosim::duration stepSize = cosim::to_duration(0.1);
 
-        const auto logPath = boost::filesystem::current_path() / "logs" / "clean";
-        boost::filesystem::create_directories(logPath);
-        boost::filesystem::remove_all(logPath);
+        const auto logPath = cosim::filesystem::current_path() / "logs" / "clean";
+        cosim::filesystem::create_directories(logPath);
+        cosim::filesystem::remove_all(logPath);
 
         // Set up the execution
         auto execution = cosim::execution(startTime, std::make_unique<cosim::fixed_step_algorithm>(stepSize));

--- a/tests/file_observer_logging_from_config_test.cpp
+++ b/tests/file_observer_logging_from_config_test.cpp
@@ -6,7 +6,7 @@
 #include <cosim/log/simple.hpp>
 #include <cosim/observer/file_observer.hpp>
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <exception>
 #include <memory>
@@ -29,10 +29,10 @@ int main()
 
         const auto testDataDir = std::getenv("TEST_DATA_DIR");
         REQUIRE(testDataDir);
-        boost::filesystem::path configPath = boost::filesystem::path(testDataDir) / "LogConfig.xml";
+        cosim::filesystem::path configPath = cosim::filesystem::path(testDataDir) / "LogConfig.xml";
 
-        const auto logPath = boost::filesystem::current_path() / "logs";
-        boost::filesystem::path csvPath = boost::filesystem::path(logPath);
+        const auto logPath = cosim::filesystem::current_path() / "logs";
+        cosim::filesystem::path csvPath = cosim::filesystem::path(logPath);
 
 
         // Set up the execution and add observer

--- a/tests/file_observer_logging_test.cpp
+++ b/tests/file_observer_logging_test.cpp
@@ -6,7 +6,7 @@
 #include <cosim/log/simple.hpp>
 #include <cosim/observer/file_observer.hpp>
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 
 #include <exception>
 #include <memory>
@@ -27,8 +27,8 @@ int main()
         constexpr cosim::time_point endTime = cosim::to_time_point(10.0);
         constexpr cosim::duration stepSize = cosim::to_duration(0.1);
 
-        const auto logPath = boost::filesystem::current_path() / "logs";
-        boost::filesystem::path csvPath = boost::filesystem::path(logPath);
+        const auto logPath = cosim::filesystem::current_path() / "logs";
+        cosim::filesystem::path csvPath = cosim::filesystem::path(logPath);
 
         // Set up the execution
         auto execution = cosim::execution(startTime, std::make_unique<cosim::fixed_step_algorithm>(stepSize));

--- a/tests/fmi_v1_fmu_unittest.cpp
+++ b/tests/fmi_v1_fmu_unittest.cpp
@@ -4,7 +4,6 @@
 #include <cosim/utility/filesystem.hpp>
 #include <cosim/utility/zip.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cstdlib>
@@ -124,7 +123,7 @@ BOOST_AUTO_TEST_CASE(v1_fmu)
     BOOST_TEST_REQUIRE(!!testDataDir);
     auto importer = fmi::importer::create();
     auto fmu = importer->import(
-        boost::filesystem::path(testDataDir) / "fmi1" / "identity.fmu");
+        cosim::filesystem::path(testDataDir) / "fmi1" / "identity.fmu");
     run_tests(fmu);
 }
 
@@ -135,7 +134,7 @@ BOOST_AUTO_TEST_CASE(v1_fmu_unpacked)
     BOOST_TEST_REQUIRE(!!testDataDir);
     utility::temp_dir unpackDir;
     utility::zip::archive(
-        boost::filesystem::path(testDataDir) / "fmi1" / "identity.fmu")
+        cosim::filesystem::path(testDataDir) / "fmi1" / "identity.fmu")
         .extract_all(unpackDir.path());
 
     auto importer = fmi::importer::create();

--- a/tests/fmi_v2_fmu_unittest.cpp
+++ b/tests/fmi_v2_fmu_unittest.cpp
@@ -2,7 +2,7 @@
 #include <cosim/fmi/importer.hpp>
 #include <cosim/fmi/v2/fmu.hpp>
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 #include <boost/test/unit_test.hpp>
 
 
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE(v2_fmu)
     auto importer = fmi::importer::create();
     const std::string modelName = "WaterTank_Control";
     auto fmu = importer->import(
-        boost::filesystem::path(testDataDir) / "fmi2" / (modelName + ".fmu"));
+        cosim::filesystem::path(testDataDir) / "fmi2" / (modelName + ".fmu"));
 
     BOOST_TEST(fmu->fmi_version() == fmi::fmi_version::v2_0);
     const auto d = fmu->model_description();
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(v2_fmu)
     BOOST_TEST(d->author.empty());
     BOOST_TEST(d->version.empty());
     BOOST_TEST(std::static_pointer_cast<fmi::v2::fmu>(fmu)->fmilib_handle() != nullptr);
-    BOOST_TEST(boost::filesystem::exists(
+    BOOST_TEST(cosim::filesystem::exists(
         std::static_pointer_cast<fmi::v2::fmu>(fmu)->directory() / "modelDescription.xml"));
 
     auto instance = fmu->instantiate_slave("testSlave");

--- a/tests/orchestration_unittest.cpp
+++ b/tests/orchestration_unittest.cpp
@@ -1,8 +1,8 @@
 #define BOOST_TEST_MODULE orchestration.hpp unittests
+#include <cosim/fs_portability.hpp>
 #include <cosim/orchestration.hpp>
 #include <cosim/uri.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(file_uri_sub_resolver_absolute_path_test)
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_TEST_REQUIRE(!!testDataDir);
-    const auto path = boost::filesystem::path(testDataDir) / "fmi2" / "Clock.fmu";
+    const auto path = cosim::filesystem::path(testDataDir) / "fmi2" / "Clock.fmu";
     const auto uri = cosim::path_to_file_uri(path);
 
     cosim::model_uri_resolver resolver;
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(file_uri_sub_resolver_relative_path_test)
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_TEST_REQUIRE(!!testDataDir);
-    const auto basePath = boost::filesystem::path(testDataDir) / "some_base";
+    const auto basePath = cosim::filesystem::path(testDataDir) / "some_base";
     const auto baseUri = cosim::path_to_file_uri(basePath);
 
     cosim::model_uri_resolver resolver;

--- a/tests/osp_config_parser_test.cpp
+++ b/tests/osp_config_parser_test.cpp
@@ -1,10 +1,9 @@
 #include <cosim/algorithm/fixed_step_algorithm.hpp>
+#include <cosim/fs_portability.hpp>
 #include <cosim/log/simple.hpp>
 #include <cosim/observer/last_value_observer.hpp>
 #include <cosim/orchestration.hpp>
 #include <cosim/osp_config_parser.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <cstdlib>
 #include <exception>
@@ -13,7 +12,7 @@
 #define REQUIRE(test) \
     if (!(test)) throw std::runtime_error("Requirement not satisfied: " #test)
 
-void test(const boost::filesystem::path& configPath, size_t expectedNumConnections)
+void test(const cosim::filesystem::path& configPath, size_t expectedNumConnections)
 {
     auto resolver = cosim::default_model_uri_resolver();
     const auto config = cosim::load_osp_config(configPath, *resolver);
@@ -50,8 +49,8 @@ int main()
 
         const auto testDataDir = std::getenv("TEST_DATA_DIR");
         REQUIRE(testDataDir);
-        test(boost::filesystem::path(testDataDir) / "msmi", 7);
-        test(boost::filesystem::path(testDataDir) / "msmi" / "OspSystemStructure_Bond.xml", 9);
+        test(cosim::filesystem::path(testDataDir) / "msmi", 7);
+        test(cosim::filesystem::path(testDataDir) / "msmi" / "OspSystemStructure_Bond.xml", 9);
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what();
         return 1;

--- a/tests/scenario_parser_unittest.cpp
+++ b/tests/scenario_parser_unittest.cpp
@@ -23,7 +23,7 @@ constexpr cosim::time_point startTime = cosim::to_time_point(0.0);
 constexpr cosim::time_point endTime = cosim::to_time_point(1.1);
 constexpr cosim::duration stepSize = cosim::to_duration(0.1);
 
-void test(const boost::filesystem::path& scenarioFile)
+void test(const cosim::filesystem::path& scenarioFile)
 {
 
     cosim::log::setup_simple_console_logging();
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(json_test)
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_REQUIRE(testDataDir != nullptr);
 
-    test(boost::filesystem::path(testDataDir) / "scenarios" / "scenario1.json");
+    test(cosim::filesystem::path(testDataDir) / "scenarios" / "scenario1.json");
 }
 
 BOOST_AUTO_TEST_CASE(yaml_test)
@@ -125,5 +125,5 @@ BOOST_AUTO_TEST_CASE(yaml_test)
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_REQUIRE(testDataDir != nullptr);
 
-    test(boost::filesystem::path(testDataDir) / "scenarios" / "scenario1.yml");
+    test(cosim::filesystem::path(testDataDir) / "scenarios" / "scenario1.yml");
 }

--- a/tests/ssp_loader_fmuproxy_test.cpp
+++ b/tests/ssp_loader_fmuproxy_test.cpp
@@ -1,7 +1,6 @@
+#include <cosim/fs_portability.hpp>
 #include <cosim/log/simple.hpp>
 #include <cosim/ssp/ssp_loader.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <cstdlib>
 #include <exception>
@@ -17,7 +16,7 @@ int main()
 
         const auto testDataDir = std::getenv("TEST_DATA_DIR");
         REQUIRE(testDataDir);
-        boost::filesystem::path sspFile = boost::filesystem::path(testDataDir) / "ssp" / "demo" / "fmuproxy";
+        cosim::filesystem::path sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "fmuproxy";
 
         cosim::ssp_loader loader;
         const auto config = loader.load(sspFile);

--- a/tests/ssp_loader_unittest.cpp
+++ b/tests/ssp_loader_unittest.cpp
@@ -1,10 +1,10 @@
 #define BOOST_TEST_MODULE ssp_loader.hpp unittests
 #include <cosim/algorithm/fixed_step_algorithm.hpp>
+#include <cosim/fs_portability.hpp>
 #include <cosim/log/simple.hpp>
 #include <cosim/observer/last_value_observer.hpp>
 #include <cosim/ssp/ssp_loader.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(basic_test)
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_REQUIRE(testDataDir != nullptr);
-    boost::filesystem::path sspFile = boost::filesystem::path(testDataDir) / "ssp" / "demo";
+    cosim::filesystem::path sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo";
 
     cosim::ssp_loader loader;
     const auto config = loader.load(sspFile);
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(no_algorithm_test)
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_REQUIRE(testDataDir != nullptr);
-    boost::filesystem::path sspFile = boost::filesystem::path(testDataDir) / "ssp" / "demo" / "no_algorithm_element";
+    cosim::filesystem::path sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "no_algorithm_element";
 
     cosim::ssp_loader loader;
     auto config = loader.load(sspFile);
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(ssp_archive)
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_TEST_REQUIRE(testDataDir != nullptr);
-    const auto sspFile = boost::filesystem::path(testDataDir) / "ssp" / "demo" / "demo.ssp";
+    const auto sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "demo.ssp";
 
     cosim::ssp_loader loader;
     const auto config = loader.load(sspFile);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(ssp_archive_multiple_ssd)
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_TEST_REQUIRE(testDataDir != nullptr);
-    const auto sspFile = boost::filesystem::path(testDataDir) / "ssp" / "demo" / "demo.ssp";
+    const auto sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "demo.ssp";
 
     cosim::ssp_loader loader;
     loader.set_ssd_file_name("SystemStructure2");
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(ssp_linear_transformation_test)
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_TEST_REQUIRE(testDataDir != nullptr);
-    const auto sspDir = boost::filesystem::path(testDataDir) / "ssp" / "linear_transformation";
+    const auto sspDir = cosim::filesystem::path(testDataDir) / "ssp" / "linear_transformation";
 
     cosim::ssp_loader loader;
     const auto config = loader.load(sspDir);
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(ssp_multiple_parameter_sets_test)
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
     BOOST_TEST_REQUIRE(testDataDir != nullptr);
-    const auto sspDir = boost::filesystem::path(testDataDir) / "ssp" / "linear_transformation";
+    const auto sspDir = cosim::filesystem::path(testDataDir) / "ssp" / "linear_transformation";
 
     cosim::ssp_loader loader;
     const auto config = loader.load(sspDir);

--- a/tests/uri_unittest.cpp
+++ b/tests/uri_unittest.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(file_uri_conversions)
 {
     // From path to URI
     BOOST_TEST(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");
-    BOOST_TEST(path_to_file_uri(boost::filesystem::path()) == "file:");
+    BOOST_TEST(path_to_file_uri(cosim::filesystem::path()) == "file:");
 #ifdef _WIN32
     BOOST_TEST(path_to_file_uri("\\foo bar\\baz") == "file:///foo%20bar/baz");
     BOOST_TEST(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");

--- a/tests/utility_filesystem_unittest.cpp
+++ b/tests/utility_filesystem_unittest.cpp
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE cosim::utility filesystem unittests
 #include <cosim/utility/filesystem.hpp>
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <utility>
@@ -9,7 +9,7 @@
 
 BOOST_AUTO_TEST_CASE(temp_dir)
 {
-    namespace fs = boost::filesystem;
+    namespace fs = cosim::filesystem;
     fs::path d;
     {
         auto tmp = cosim::utility::temp_dir();

--- a/tests/utility_zip_unittest.cpp
+++ b/tests/utility_zip_unittest.cpp
@@ -2,7 +2,7 @@
 #include <cosim/utility/filesystem.hpp>
 #include <cosim/utility/zip.hpp>
 
-#include <boost/filesystem.hpp>
+#include <cosim/fs_portability.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <cstdlib>
@@ -13,7 +13,7 @@ BOOST_AUTO_TEST_CASE(zip_archive)
 {
     namespace ut = cosim::utility;
     namespace uz = cosim::utility::zip;
-    namespace fs = boost::filesystem;
+    namespace fs = cosim::filesystem;
 
     // Info about the test archive file and its contents
     const std::uint64_t archiveEntryCount = 3;


### PR DESCRIPTION
This PR replaces usage of boost::filesystem with std::filesystem.
In order to support gcc7, the header `fs_portability` is used, which falls back to std::experimental::filesystem.
Thus, usage of `std::filesystem` should be done using the typealias `cosim::filesystem`