### PR TITLE
overriding xz_utils

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,8 @@ class LibcosimConan(ConanFile):
         "yaml-cpp/0.6.3",
         "xerces-c/3.2.2",
         # conflict resolution
-        "openssl/1.1.1k"
+        "openssl/1.1.1k",
+        "xz_utils/5.2.5"
     )
 
     options = {"fmuproxy": [True, False]}


### PR DESCRIPTION
Resolving conflict in linux builds:

```
ERROR: Conflict in libzip/1.7.3:
    'libzip/1.7.3' requires 'xz_utils/5.2.5' while 'libunwind/1.5.0' requires 'xz_utils/5.2.4'.
    To fix this conflict you need to override the package 'xz_utils' in your root package.
```