### PR TITLE
Clean up Conan CI build environment using Docker and run tests in Conan CI builds

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -67,6 +67,7 @@ jobs:
       CONAN_NON_INTERACTIVE: True
       CONAN_USE_ALWAYS_SHORT_PATHS: True
       CONAN_USER_HOME_SHORT: C:\c
+      LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD: True
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -3,24 +3,13 @@ name: libcosim CI Conan
 # This workflow is triggered on pushes to the repository.
 on: [push, workflow_dispatch]
 
-env:
-  CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
-  CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
-  CONAN_REVISIONS_ENABLED: 1
-  CONAN_NON_INTERACTIVE: True
-  CONAN_USE_ALWAYS_SHORT_PATHS: True
-
 jobs:
   conan-on-linux:
     name: Conan
-    runs-on: ${{ matrix.os }}
-    env:
-      CC: gcc-${{ matrix.compiler_version }}
-      CXX: g++-${{ matrix.compiler_version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
         build_type: [Debug, Release]
         compiler_version: [7, 8, 9]
         compiler_libcxx: [libstdc++11]
@@ -28,16 +17,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install prerequisites
+      - name: Generate Dockerfile
         run: |
-          sudo apt-get install -y --no-install-recommends \
-            g++-8
-          sudo pip3 install --upgrade setuptools pip
-          sudo pip3 install conan
-      - name: Configure Conan
-        run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
-      - name: Conan create
+          mkdir /tmp/osp-builder-docker
+          cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
+          FROM conanio/gcc${{ matrix.compiler_version }}
+          ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
+          ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
+          ENV CONAN_REVISIONS_ENABLED=1
+          ENV CONAN_NON_INTERACTIVE=True
+          ENV CONAN_USE_ALWAYS_SHORT_PATHS=True
+          ENV LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD=True
+          COPY entrypoint.sh /
+          ENTRYPOINT /entrypoint.sh
+          EOF
+      - name: Generate entrypoint.sh
         run: |
+          cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
+          #!/bin/bash -v
+          set -eu
+          cd /mnt/source
+          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
           REFNAME="${GITHUB_REF#refs/*/}"
           VERSION="v$(<version.txt)"
           if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"
@@ -47,16 +47,26 @@ jobs:
             CHANNEL="testing-${SHORT_REFNAME//\//_}"
           fi
           conan create -s build_type=${{ matrix.build_type }} -s compiler.version=${{ matrix.compiler_version }} -s compiler.libcxx=${{ matrix.compiler_libcxx }} -o ${{ matrix.option_fmuproxy }} -b missing . osp/${CHANNEL}
-      - name: Conan upload
-        run: |
           conan upload --all -c -r osp '*'
+          EOF
+          chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
+      - name: Build Docker image
+        run: |
+          docker build -t osp-builder /tmp/osp-builder-docker/
+      - name: Build cosim
+        run: |
+          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
 
   conan-on-windows:
     name: Conan
     runs-on: ${{ matrix.os }}
     env:
+      CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
+      CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
+      CONAN_REVISIONS_ENABLED: 1
+      CONAN_NON_INTERACTIVE: True
+      CONAN_USE_ALWAYS_SHORT_PATHS: True
       CONAN_USER_HOME_SHORT: C:\c
-      CONAN_USE_ALWAYS_SHORT_PATHS: 1
     strategy:
       fail-fast: false
       matrix:
@@ -64,11 +74,6 @@ jobs:
         build_type: [Debug, Release]
         compiler_version: [15]
         option_fmuproxy: ['fmuproxy=True', 'fmuproxy=False']
-
-        exclude:
-          - os: windows-2016
-            build_type: Debug
-            option_fmuproxy: 'fmuproxy=True'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -64,10 +64,10 @@ jobs:
       CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
       CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
       CONAN_REVISIONS_ENABLED: 1
-      CONAN_NON_INTERACTIVE: True
-      CONAN_USE_ALWAYS_SHORT_PATHS: True
+      CONAN_NON_INTERACTIVE: 1
+      CONAN_USE_ALWAYS_SHORT_PATHS: 1
       CONAN_USER_HOME_SHORT: C:\c
-      LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD: True
+      LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD: 1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This change was motivated by some test failures in PR #633 which are almost surely unrelated to the PR itself. The probable diagnosis is simply that the build environment provided by GitHub's workflow runners is so messy that some unwanted library inadvertently gets picked up from *outside* the Conan package ecosystem. (We add to the mess by installing an additional GCC version, which happens to be the version for which the tests fail...)

Long story short, here I've set up a cleaner build environment using Docker. The building still takes place on GitHub's runners, but is now isolated from the messy host environment inside a Docker container. The base environments for the different compilers are [the ones used for Conan Center](https://github.com/conan-io/conan-docker-tools).

The process, described in the Linux part of `.github/workflows/ci-conan.yml`, now goes like this:
1. Generate `/tmp/osp-builder-docker/Dockerfile `, which defines the build environment as a Docker image.
2. Generate `/tmp/osp-builder-docker/entrypoint.sh`, which gets copied into the Docker image as `/entrypoint.sh` and contains the actual _libcosim_ build steps.
3. Build a Docker image named `osp-builder` based on the above files.
4. Run a Docker container based off `osp-builder`, i.e., run `/entrypoint.sh` inside the build environment. The source folder which is checked out on the host runner gets mounted read-only at `/mnt/source` inside the container.

I've included a change which was originally in #633, namely the addition of the environment variable `LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD`, added so we can run tests in Conan-based CI builds too.