### PR TITLE
Use "1" as true value for environment variables

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -7,7 +7,7 @@ env:
   CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
   CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
   CONAN_REVISIONS_ENABLED: 1
-  CONAN_NON_INTERACTIVE: True
+  CONAN_NON_INTERACTIVE: 1
 
 jobs:
   cmake-on-linux:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -25,9 +25,9 @@ jobs:
           ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
           ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
           ENV CONAN_REVISIONS_ENABLED=1
-          ENV CONAN_NON_INTERACTIVE=True
-          ENV CONAN_USE_ALWAYS_SHORT_PATHS=True
-          ENV LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD=True
+          ENV CONAN_NON_INTERACTIVE=1
+          ENV CONAN_USE_ALWAYS_SHORT_PATHS=1
+          ENV LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD=1
           COPY entrypoint.sh /
           ENTRYPOINT /entrypoint.sh
           EOF


### PR DESCRIPTION
Conan only understands the values "True" or "1" for its configuration variables.  However, in a YAML file, the value "True" gets intepreted as a boolean rather than a string and converted to lowercase "true" at some point by GitHub Actions. Conan does *not* understand that and interprets it as "False" instead.

This is not actually a problem in the part of `ci-conan.yml` which generates the `Dockerfile`, as Docker does no such interpretation.  But it's less confusing and more future-proof to stick to one convention everywhere.

Some instances of this were fixed in #644.