### PR TITLE
Bug/646 observer memory leaks

### DIFF
--- a/include/cosim/observer/file_observer.hpp
+++ b/include/cosim/observer/file_observer.hpp
@@ -45,7 +45,7 @@ public:
      * \param logDir the directory where log files will be created.
      * \param configPath the path to an xml file containing the logging configuration.
      */
-    file_observer(const cosim::filesystem::path& logDir, const cosim::filesystem::path& configPath);
+    file_observer(const cosim::filesystem::path& logDir, cosim::filesystem::path  configPath);
 
     /**
      * Returns whether the observer is currently recording values.

--- a/include/cosim/observer/file_observer.hpp
+++ b/include/cosim/observer/file_observer.hpp
@@ -45,7 +45,7 @@ public:
      * \param logDir the directory where log files will be created.
      * \param configPath the path to an xml file containing the logging configuration.
      */
-    file_observer(const cosim::filesystem::path& logDir, cosim::filesystem::path  configPath);
+    file_observer(const cosim::filesystem::path& logDir, const cosim::filesystem::path& configPath);
 
     /**
      * Returns whether the observer is currently recording values.

--- a/include/cosim/observer/time_series_observer.hpp
+++ b/include/cosim/observer/time_series_observer.hpp
@@ -33,7 +33,7 @@ class time_series_observer : public time_series_provider
 {
 public:
     /**
-     * Default constructor. Creates an unbuffered `time_series_observer`.
+     * Default constructor. Creates a buffered `time_series_observer`, with a fixed buffer size of 10000 samples for each observed variable.
      */
     time_series_observer();
 

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -9,7 +9,6 @@
 #include "cosim/log/logger.hpp"
 
 #include <boost/date_time/local_time/local_time.hpp>
-#include <utility>
 #include <boost/property_tree/xml_parser.hpp>
 
 #include <algorithm>

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -278,8 +278,8 @@ file_observer::file_observer(const cosim::filesystem::path& logDir)
 {
 }
 
-file_observer::file_observer(const cosim::filesystem::path& logDir, cosim::filesystem::path  configPath)
-    : configPath_(std::move(configPath))
+file_observer::file_observer(const cosim::filesystem::path& logDir, const cosim::filesystem::path& configPath)
+    : configPath_(configPath)
     , logDir_(cosim::filesystem::absolute(logDir))
     , logFromConfig_(true)
 {

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -130,10 +130,10 @@ public:
 
 private:
     template<typename T>
-    void write(const std::vector<T>& values, std::stringstream& ss_)
+    void write(const std::vector<T>& values, std::stringstream& ss)
     {
         for (auto it = values.begin(); it != values.end(); ++it) {
-            ss_ << "," << *it;
+            ss << "," << *it;
         }
     }
 
@@ -190,7 +190,7 @@ private:
     void create_log_file()
     {
         std::string filename;
-        std::stringstream ss_;
+        std::stringstream ss;
         if (!timeStampedFileNames_) {
             filename = observable_->name().append(".csv");
         } else {
@@ -206,45 +206,45 @@ private:
             throw std::runtime_error("Failed to open file stream for logging");
         }
 
-        ss_ << "Time,StepCount";
+        ss << "Time,StepCount";
 
         for (const auto& vd : realVars_) {
-            ss_ << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
         }
         for (const auto& vd : intVars_) {
-            ss_ << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
         }
         for (const auto& vd : boolVars_) {
-            ss_ << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
         }
         for (const auto& vd : stringVars_) {
-            ss_ << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
         }
 
-        ss_ << std::endl;
+        ss << std::endl;
 
         if (fsw_.is_open()) {
-            fsw_ << ss_.rdbuf();
+            fsw_ << ss.rdbuf();
         }
     }
 
     void persist()
     {
-        std::stringstream ss_;
+        std::stringstream ss;
         if (fsw_.is_open()) {
 
             for (const auto& [stepCount, times] : timeSamples_) {
-                ss_ << times << "," << stepCount;
+                ss << times << "," << stepCount;
 
-                if (realSamples_.count(stepCount)) write<double>(realSamples_[stepCount], ss_);
-                if (intSamples_.count(stepCount)) write<int>(intSamples_[stepCount], ss_);
-                if (boolSamples_.count(stepCount)) write<bool>(boolSamples_[stepCount], ss_);
-                if (stringSamples_.count(stepCount)) write<std::string_view>(stringSamples_[stepCount], ss_);
+                if (realSamples_.count(stepCount)) write<double>(realSamples_[stepCount], ss);
+                if (intSamples_.count(stepCount)) write<int>(intSamples_[stepCount], ss);
+                if (boolSamples_.count(stepCount)) write<bool>(boolSamples_[stepCount], ss);
+                if (stringSamples_.count(stepCount)) write<std::string_view>(stringSamples_[stepCount], ss);
 
-                ss_ << std::endl;
+                ss << std::endl;
             }
 
-            fsw_ << ss_.rdbuf();
+            fsw_ << ss.rdbuf();
         }
 
         realSamples_.clear();

--- a/src/cosim/observer/time_series_observer.cpp
+++ b/src/cosim/observer/time_series_observer.cpp
@@ -191,7 +191,7 @@ public:
         steps[1] = lastStep;
     }
 
-    const std::map<step_number, double> get_real_samples_map(value_reference idx)
+    std::map<step_number, double> get_real_samples_map(value_reference idx)
     {
         std::lock_guard<std::mutex> lock(lock_);
         return realSamples_.at(idx);
@@ -207,7 +207,7 @@ private:
 };
 
 time_series_observer::time_series_observer()
-    : bufSize_(0)
+    : bufSize_(20000)
 {
 }
 

--- a/src/cosim/observer/time_series_observer.cpp
+++ b/src/cosim/observer/time_series_observer.cpp
@@ -204,13 +204,19 @@ private:
 };
 
 time_series_observer::time_series_observer()
-    : bufSize_(20000)
+    : bufSize_(10000)
 {
 }
 
 time_series_observer::time_series_observer(size_t bufferSize)
 {
-    if (bufferSize > 0) bufSize_ = bufferSize;
+    if (bufferSize > 0)  {
+        bufSize_ = bufferSize;
+    } else {
+        std::ostringstream oss;
+        oss << "Can't define an observer with buffer size " << bufferSize << ", minimum allowed buffer size is 1.";
+        throw std::invalid_argument(oss.str());
+    }
 }
 
 void time_series_observer::simulator_added(simulator_index index, observable* simulator, time_point currentTime)

--- a/src/cosim/observer/time_series_observer.cpp
+++ b/src/cosim/observer/time_series_observer.cpp
@@ -58,9 +58,6 @@ size_t get_samples(
 template<typename T>
 void adjustIfFull(std::map<step_number, T>& buffer, size_t maxSize)
 {
-    if (maxSize <= 0) {
-        return;
-    }
     if (buffer.size() > maxSize) {
         buffer.erase(buffer.begin());
     }
@@ -212,8 +209,8 @@ time_series_observer::time_series_observer()
 }
 
 time_series_observer::time_series_observer(size_t bufferSize)
-    : bufSize_(bufferSize)
 {
+    if (bufferSize > 0) bufSize_ = bufferSize;
 }
 
 void time_series_observer::simulator_added(simulator_index index, observable* simulator, time_point currentTime)


### PR DESCRIPTION
This PR aims to fix the memory leaks in `time_series_observer.cpp` and `file_observer.cpp`. 

For `file_observer`, the `std::stringstream ss_` that was "collecting" data to write to file has been reduced in scope to a local variable in the functions that used it. 

For `time_series_observer`, the culprit was the zero argument constructor requesting a buffer size of 0, which bypassed the `adjustIfFull `test and led to constantly increasing buffer sizes for all variable types. The zero argument constructor will now instead provide a default buffer size of `10000` samples. A zero sample observer is no longer allowed and will throw, the minimum buffer size is 1. 

The changes have been tested with cosim-cli and memory use found to be stable at 5-6 MB over a 6000 second simulation of the techlaunch-tutorial configuration while logging everything. Running the same simulation on the current master branch leads to memory usage steadily climbing to 10 times that. 