### PR TITLE
Stopped flag is now set true after simulate_until loop is finished

### DIFF
--- a/src/cosim/execution.cpp
+++ b/src/cosim/execution.cpp
@@ -151,7 +151,7 @@ public:
             do {
                 stepSize = step();
                 timer_.sleep(currentTime_);
-            }  while (!stopped_ && !timed_out(endTime, currentTime_, stepSize));
+            } while (!stopped_ && !timed_out(endTime, currentTime_, stepSize));
             bool isStopped = stopped_;
             stopped_ = true;
             return !isStopped;

--- a/src/cosim/execution.cpp
+++ b/src/cosim/execution.cpp
@@ -151,8 +151,10 @@ public:
             do {
                 stepSize = step();
                 timer_.sleep(currentTime_);
-            } while (!stopped_ && !timed_out(endTime, currentTime_, stepSize));
-            return !stopped_;
+            }  while (!stopped_ && !timed_out(endTime, currentTime_, stepSize));
+            bool isStopped = stopped_;
+            stopped_ = true;
+            return !isStopped;
         });
     }
 


### PR DESCRIPTION
Possible fix to one of the issues described in #654 with the `simulate_until()` function not setting the `stopped_` flag to `true` after the optional stop time has been reached, as if it was paused manually at the stop time 