### PR TITLE
Update proxyfmu to 0.2.6

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,7 @@ class LibcosimConan(ConanFile):
 
     def requirements(self):
         if self.options.proxyfmu:
-            self.requires("proxyfmu/0.2.5@osp/stable")
+            self.requires("proxyfmu/0.2.6@osp/stable")
 
     def imports(self):
         binDir = os.path.join("output", str(self.settings.build_type).lower(), "bin")


### PR DESCRIPTION
Fixes a weird issue where versions of libcosim built with VS2017 would fail with proxyfmu_booter