### PR TITLE
Passing thread_count from the ctor.

### DIFF
--- a/include/cosim/algorithm/fixed_step_algorithm.hpp
+++ b/include/cosim/algorithm/fixed_step_algorithm.hpp
@@ -31,8 +31,11 @@ public:
      *
      *  \param baseStepSize
      *      The base communication interval length.
+     *
+     *  \param workerThreadCount
+     *      A number of worker threads to spawn for running FMUs
      */
-    explicit fixed_step_algorithm(duration baseStepSize, unsigned int thread_count = std::thread::hardware_concurrency());
+    explicit fixed_step_algorithm(duration baseStepSize, unsigned int workerThreadCount = std::thread::hardware_concurrency());
 
     ~fixed_step_algorithm() noexcept;
 

--- a/include/cosim/algorithm/fixed_step_algorithm.hpp
+++ b/include/cosim/algorithm/fixed_step_algorithm.hpp
@@ -11,6 +11,7 @@
 #define LIBCOSIM_ALGORITHM_FIXED_STEP_ALGORITHM_HPP
 
 #include <cosim/algorithm/algorithm.hpp>
+#include <thread>
 
 namespace cosim
 {
@@ -31,7 +32,7 @@ public:
      *  \param baseStepSize
      *      The base communication interval length.
      */
-    explicit fixed_step_algorithm(duration baseStepSize);
+    explicit fixed_step_algorithm(duration baseStepSize, unsigned int thread_count = std::thread::hardware_concurrency());
 
     ~fixed_step_algorithm() noexcept;
 

--- a/src/cosim/algorithm/fixed_step_algorithm.cpp
+++ b/src/cosim/algorithm/fixed_step_algorithm.cpp
@@ -49,9 +49,9 @@ int calculate_decimation_factor(
 class fixed_step_algorithm::impl
 {
 public:
-    explicit impl(duration baseStepSize, unsigned int thread_count)
+    explicit impl(duration baseStepSize, unsigned int workerThreadCount)
         : baseStepSize_(baseStepSize)
-        , pool(thread_count)
+        , pool(workerThreadCount)
     {
         COSIM_INPUT_CHECK(baseStepSize.count() > 0);
     }
@@ -436,8 +436,8 @@ private:
 };
 
 
-fixed_step_algorithm::fixed_step_algorithm(duration baseStepSize, unsigned int thread_count)
-    : pimpl_(std::make_unique<impl>(baseStepSize, thread_count))
+fixed_step_algorithm::fixed_step_algorithm(duration baseStepSize, unsigned int workerThreadCount)
+    : pimpl_(std::make_unique<impl>(baseStepSize, workerThreadCount))
 {
 }
 

--- a/src/cosim/algorithm/fixed_step_algorithm.cpp
+++ b/src/cosim/algorithm/fixed_step_algorithm.cpp
@@ -49,8 +49,9 @@ int calculate_decimation_factor(
 class fixed_step_algorithm::impl
 {
 public:
-    explicit impl(duration baseStepSize)
+    explicit impl(duration baseStepSize, unsigned int thread_count)
         : baseStepSize_(baseStepSize)
+        , pool(thread_count)
     {
         COSIM_INPUT_CHECK(baseStepSize.count() > 0);
     }
@@ -435,8 +436,8 @@ private:
 };
 
 
-fixed_step_algorithm::fixed_step_algorithm(duration baseStepSize)
-    : pimpl_(std::make_unique<impl>(baseStepSize))
+fixed_step_algorithm::fixed_step_algorithm(duration baseStepSize, unsigned int thread_count)
+    : pimpl_(std::make_unique<impl>(baseStepSize, thread_count))
 {
 }
 


### PR DESCRIPTION
Just added a small modification to pass `thread_count` via ctor of fixed_step_algorithm. When `threads_.empty()`, thread_pool executes the function directly without queuing.