### PR TITLE
Retire VS 2016, gcc7 and gcc8

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         build_type: [Debug, Release]
-        compiler_version: [7]
+        compiler_version: [9]
         shared_libs: [ON, OFF]
 
     steps:
@@ -65,17 +65,16 @@ jobs:
           name: libcosim-${{ runner.os }}-${{ matrix.build_type }}-gcc${{ matrix.compiler_version }}
           path: install
 
+
   cmake-on-windows:
     name: CMake
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2019]
         build_type: [Debug, Release]
         shared: ["True", "False"]
-
-
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [7, 8, 9]
+        compiler_version: [9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']
@@ -58,6 +58,7 @@ jobs:
         run: |
           docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
 
+
   conan-on-windows:
     name: Conan
     runs-on: ${{ matrix.os }}
@@ -72,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2019]
         build_type: [Debug, Release]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']


### PR DESCRIPTION
This PR removes old compilers from the CI. It does not add new ones.
VS2016 must be removed soon anyway (deprecated in the runners). 
gcc7 and gcc8 does not support `<execution>` in C++17, which we aim to use in the future. 