### PR TITLE
Retire VS2016

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -65,17 +65,16 @@ jobs:
           name: libcosim-${{ runner.os }}-${{ matrix.build_type }}-gcc${{ matrix.compiler_version }}
           path: install
 
+
   cmake-on-windows:
     name: CMake
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2019]
         build_type: [Debug, Release]
         shared: ["True", "False"]
-
-
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
 
+
   conan-on-windows:
     name: Conan
     runs-on: ${{ matrix.os }}
@@ -72,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2019]
         build_type: [Debug, Release]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']


### PR DESCRIPTION
Only remove VS2016 compiler from CI for now.

Superseeds #683 

Closes #667 