### PR TITLE
Add timeout to runners

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -23,6 +23,7 @@ jobs:
         build_type: [Debug, Release]
         compiler_version: [7]
         shared_libs: [ON, OFF]
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v2
@@ -75,6 +76,7 @@ jobs:
         os: [windows-2019]
         build_type: [Debug, Release]
         shared: ["True", "False"]
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -15,6 +15,7 @@ jobs:
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v2
@@ -77,6 +78,7 @@ jobs:
         build_type: [Debug, Release]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']
+    timeout-minutes: 35
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
One of my PR got stuck for over 4 hours a couple of days ago before I noticed and manually terminated the run.
A timeout should be considered.