### PR TITLE
Correct or remove minimum version specs in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ in the section below or you can use conan. As libcosim is made available as a
 conan package on https://osp.jfrog.io, you can include it in your application
 following these steps:
 
-* Install [Conan] >= 1.7
+* Install [Conan]
 * Add the OSP Conan repository as a remote: 
 
        conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local
@@ -35,10 +35,10 @@ How to build
 
 ### Required tools
 
-  * Compilers: [Visual Studio] >= 2017 (Windows), GCC >= 8 (Linux)
-  * Build tool: [CMake] >= 3.9
-  * API documentation generator (optional): [Doxygen] >= 1.8
-  * Package manager (optional): [Conan] >= 1.7
+  * Compilers: [Visual Studio] >= 16.0/2019 (Windows), GCC >= 7 (Linux)
+  * Build tool: [CMake]
+  * API documentation generator (optional): [Doxygen]
+  * Package manager (optional): [Conan]
 
 Throughout this guide, we will use Conan to manage dependencies.  However, it
 should be possible to use other package managers as well, such as [vcpkg], and


### PR DESCRIPTION
Pretty much all of them were wrong or misleading. It's very hard to remember to keep these up to date, and it's also difficult to know exactly which versions will work. So I suggest that we specify just the compiler versions we're testing in CI and leave the other tool versions unspecified.  (The minimum CMake version has to be specified in `CMakeLists.txt`, though.)