### PR TITLE
parseURI null check and error handling implemented

### DIFF
--- a/src/cosim/osp_config_parser.cpp
+++ b/src/cosim/osp_config_parser.cpp
@@ -610,13 +610,9 @@ struct extended_model_description
         const auto domImpl = xercesc::DOMImplementationRegistry::getDOMImplementation(tc("LS").get());
         const auto parser = static_cast<xercesc::DOMImplementationLS*>(domImpl)->createLSParser(xercesc::DOMImplementationLS::MODE_SYNCHRONOUS, tc("http://www.w3.org/2001/XMLSchema").get());
 
-        error_handler errorHandler;
-
-        parser->getDomConfig()->setParameter(xercesc::XMLUni::fgDOMErrorHandler, &errorHandler);
-
         const auto doc = parser->parseURI(ospModelDescription.string().c_str());
 
-        if (doc == nullptr || errorHandler.failed()) {
+        if (doc == nullptr) {
             std::ostringstream oss;
             oss << "Validation of " << ospModelDescription.string() << " failed.";
             BOOST_LOG_SEV(log::logger(), log::error) << oss.str();


### PR DESCRIPTION
Although, only null check was suggested in the comment, implemented error handling too. And used the same message for both error handling and null check, which could be a bit confusing sometime. Feedback on these from the maintainers would be quite helpful.

NB. All the tests passed though.
![Selection_010](https://user-images.githubusercontent.com/6243408/185209176-fa4f53c7-5fe4-4521-b770-4c4e1642a96c.png)
 