### PR TITLE
Proxyfmu/0.2.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,6 @@ endif()
 
 # Our custom CMake scripts go in the cmake/ subdirectory.
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
-list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 # Use a common output directory for all targets.
 # The main purpose of this is to ensure that the DLLs and test executables
@@ -101,6 +99,9 @@ set(LIBCOSIM_EXPORT_TARGET "${PROJECT_NAME}-targets")
 # ==============================================================================
 
 if(LIBCOSIM_USING_CONAN)
+
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
     if(NOT LIBCOSIM_USING_CONAN_AUTO_CONFIG OR CONAN_EXPORTED)
         # Opting for manual invocation of conan install prior to loading CMake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ endif()
 
 # Our custom CMake scripts go in the cmake/ subdirectory.
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 # Use a common output directory for all targets.
 # The main purpose of this is to ensure that the DLLs and test executables

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class LibcosimConan(ConanFile):
         "revision": "auto"
     }
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "virtualrunenv"
+    generators = "cmake", "cmake_find_package", "virtualrunenv"
     requires = (
         "boost/1.71.0",
         "fmilibrary/2.3",
@@ -53,7 +53,7 @@ class LibcosimConan(ConanFile):
 
     def requirements(self):
         if self.options.proxyfmu:
-            self.requires("proxyfmu/0.2.7@osp/stable")
+            self.requires("proxyfmu/0.2.9@osp/testing-update-config")
 
     def imports(self):
         binDir = os.path.join("output", str(self.settings.build_type).lower(), "bin")

--- a/conanfile.py
+++ b/conanfile.py
@@ -53,7 +53,7 @@ class LibcosimConan(ConanFile):
 
     def requirements(self):
         if self.options.proxyfmu:
-            self.requires("proxyfmu/0.2.9@osp/testing-update-config")
+            self.requires("proxyfmu/0.2.9@osp/stable")
 
     def imports(self):
         binDir = os.path.join("output", str(self.settings.build_type).lower(), "bin")


### PR DESCRIPTION
Update proxyfmu to 0.2.9

proxyfmu now uses the `cmake_find_package` generator, so we need to apply it here too.