### PR TITLE
Replace boost::test with Catch2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -28,7 +28,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:      '^[<"]cosim[/.]'
     Priority:   20
-  - Regex:      '^[<"](boost|event2|fmilib|gsl|nlohmann|proxyfmu|xercesc|zip)[/.]'
+  - Regex:      '^[<"](boost|catch|fmilib|gsl|nlohmann|proxyfmu|xercesc|zip)[/.]'
     Priority:   30
   - Regex:      '^"'
     Priority:   10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.15)
 file(STRINGS "${CMAKE_SOURCE_DIR}/version.txt" projectVersion)
 project("libcosim" VERSION ${projectVersion})
 message("Current libcosim version: ${CMAKE_PROJECT_VERSION}\n")
@@ -139,7 +139,13 @@ endif()
 
 set(Boost_components date_time log)
 if (LIBCOSIM_BUILD_TESTS)
-    list(APPEND Boost_components timer unit_test_framework)
+    Include(FetchContent)
+    FetchContent_Declare(
+            Catch2
+            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+            GIT_TAG v2.13.8
+    )
+    FetchContent_MakeAvailable(Catch2)
 endif()
 if(NOT BUILD_SHARED_LIBS AND NOT DEFINED Boost_USE_STATIC_LIBS)
     set(Boost_USE_STATIC_LIBS ON)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,7 +53,7 @@ endforeach()
 
 foreach(test IN LISTS unittests)
 
-    set(dependencies cosim "Boost::unit_test_framework" "Boost::timer")
+    set(dependencies cosim "Catch2::Catch2")
     if (LIBCOSIM_WITH_PROXYFMU)
         list(APPEND dependencies "proxyfmu::proxyfmu-client")
     endif()

--- a/tests/fmi_v1_fmu_unittest.cpp
+++ b/tests/fmi_v1_fmu_unittest.cpp
@@ -1,32 +1,30 @@
-#define BOOST_TEST_MODULE cosim::fmi::v1::fmu unittest
+
 #include <cosim/fmi/importer.hpp>
 #include <cosim/fmi/v1/fmu.hpp>
 #include <cosim/utility/filesystem.hpp>
 #include <cosim/utility/zip.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <cstdlib>
 
 
 using namespace cosim;
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(fmi::fmi_version)
-BOOST_TEST_DONT_PRINT_LOG_VALUE(step_result)
-
 namespace
 {
 void run_tests(std::shared_ptr<fmi::fmu> fmu)
 {
-    BOOST_TEST(fmu->fmi_version() == fmi::fmi_version::v1_0);
+    CHECK(fmu->fmi_version() == fmi::fmi_version::v1_0);
     const auto d = fmu->model_description();
-    BOOST_TEST(d->name == "no.viproma.demo.identity");
-    BOOST_TEST(d->uuid.size() == 36U);
-    BOOST_TEST(d->description ==
+    CHECK(d->name == "no.viproma.demo.identity");
+    CHECK(d->uuid.size() == 36U);
+    CHECK(d->description ==
         "Has one input and one output of each type, and outputs are always set equal to inputs");
-    BOOST_TEST(d->author == "Lars Tandle Kyllingstad");
-    BOOST_TEST(d->version == "0.3");
-    BOOST_TEST(std::static_pointer_cast<fmi::v1::fmu>(fmu)->fmilib_handle() != nullptr);
+    CHECK(d->author == "Lars Tandle Kyllingstad");
+    CHECK(d->version == "0.3");
+    CHECK(std::static_pointer_cast<fmi::v1::fmu>(fmu)->fmilib_handle() != nullptr);
 
     cosim::value_reference
         realIn = 0,
@@ -52,22 +50,22 @@ void run_tests(std::shared_ptr<fmi::fmu> fmu)
         }
 
         if (v.name == "realIn") {
-            BOOST_TEST(v.type == variable_type::real);
-            BOOST_TEST(v.variability == variable_variability::discrete);
-            BOOST_TEST(v.causality == variable_causality::input);
+            CHECK(v.type == variable_type::real);
+            CHECK(v.variability == variable_variability::discrete);
+            CHECK(v.causality == variable_causality::input);
             double start = std::get<double>(*v.start);
-            BOOST_TEST(start == 0.0);
+            CHECK(start == 0.0);
         } else if (v.name == "stringOut") {
-            BOOST_TEST(v.type == variable_type::string);
-            BOOST_TEST(v.variability == variable_variability::discrete);
-            BOOST_TEST(v.causality == variable_causality::output);
-            BOOST_TEST(!v.start.has_value());
+            CHECK(v.type == variable_type::string);
+            CHECK(v.variability == variable_variability::discrete);
+            CHECK(v.causality == variable_causality::output);
+            CHECK(!v.start.has_value());
         } else if (v.name == "booleanIn") {
-            BOOST_TEST(v.type == variable_type::boolean);
-            BOOST_TEST(v.variability == variable_variability::discrete);
-            BOOST_TEST(v.causality == variable_causality::input);
+            CHECK(v.type == variable_type::boolean);
+            CHECK(v.variability == variable_variability::discrete);
+            CHECK(v.causality == variable_causality::input);
             bool start = std::get<bool>(*v.start);
-            BOOST_TEST(start == false);
+            CHECK(start == false);
         }
     }
 
@@ -94,10 +92,10 @@ void run_tests(std::shared_ptr<fmi::fmu> fmu)
         instance->get_boolean_variables(gsl::make_span(&booleanOut, 1), gsl::make_span(&getBooleanVal, 1));
         instance->get_string_variables(gsl::make_span(&stringOut, 1), gsl::make_span(&getStringVal, 1));
 
-        BOOST_TEST(getRealVal == realVal);
-        BOOST_TEST(getIntegerVal == integerVal);
-        BOOST_TEST(getBooleanVal == booleanVal);
-        BOOST_TEST(getStringVal == stringVal);
+        CHECK(getRealVal == realVal);
+        CHECK(getIntegerVal == integerVal);
+        CHECK(getBooleanVal == booleanVal);
+        CHECK(getStringVal == stringVal);
 
         realVal += 1.0;
         integerVal += 1;
@@ -109,7 +107,7 @@ void run_tests(std::shared_ptr<fmi::fmu> fmu)
         instance->set_boolean_variables(gsl::make_span(&booleanIn, 1), gsl::make_span(&booleanVal, 1));
         instance->set_string_variables(gsl::make_span(&stringIn, 1), gsl::make_span(&stringVal, 1));
 
-        BOOST_TEST(instance->do_step(t, dt) == step_result::complete);
+        CHECK(instance->do_step(t, dt) == step_result::complete);
     }
 
     instance->end_simulation();
@@ -117,10 +115,10 @@ void run_tests(std::shared_ptr<fmi::fmu> fmu)
 } // namespace
 
 
-BOOST_AUTO_TEST_CASE(v1_fmu)
+TEST_CASE("v1_fmu")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
     auto importer = fmi::importer::create();
     auto fmu = importer->import(
         cosim::filesystem::path(testDataDir) / "fmi1" / "identity.fmu");
@@ -128,10 +126,10 @@ BOOST_AUTO_TEST_CASE(v1_fmu)
 }
 
 
-BOOST_AUTO_TEST_CASE(v1_fmu_unpacked)
+TEST_CASE("v1_fmu_unpacked")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
     utility::temp_dir unpackDir;
     utility::zip::archive(
         cosim::filesystem::path(testDataDir) / "fmi1" / "identity.fmu")

--- a/tests/function_unittest.cpp
+++ b/tests/function_unittest.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE function unittests
+
 #include "mock_slave.hpp"
 
 #include <cosim/algorithm/fixed_step_algorithm.hpp>
@@ -7,7 +7,8 @@
 #include <cosim/manipulator/scenario_manager.hpp>
 #include <cosim/observer/time_series_observer.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <iostream>
 #include <stdexcept>
@@ -38,7 +39,7 @@ std::pair<int, int> find_io(
 }
 
 
-BOOST_AUTO_TEST_CASE(linear_transformation_standalone)
+TEST_CASE("linear_transformation_standalone")
 {
     constexpr double offset = 3.0;
     constexpr double factor = 5.0;
@@ -52,24 +53,24 @@ BOOST_AUTO_TEST_CASE(linear_transformation_standalone)
 
     const auto fun = type.instantiate(params);
     const auto funDesc = fun->description();
-    BOOST_TEST_REQUIRE(funDesc.io_groups.size() == 2);
-    BOOST_TEST_REQUIRE(funDesc.io_groups[0].ios.size() == 1);
-    BOOST_TEST_REQUIRE(funDesc.io_groups[1].ios.size() == 1);
+    REQUIRE(funDesc.io_groups.size() == 2);
+    REQUIRE(funDesc.io_groups[0].ios.size() == 1);
+    REQUIRE(funDesc.io_groups[1].ios.size() == 1);
 
     const auto [inGID, inVID] = find_io(funDesc, "in");
     const auto [outGID, outVID] = find_io(funDesc, "out");
 
     fun->set_real({inGID, 0, inVID, 0}, 10.0);
     fun->calculate();
-    BOOST_TEST(fun->get_real({outGID, 0, outVID, 0}) == 53.0);
+    CHECK(fun->get_real({outGID, 0, outVID, 0}) == 53.0);
 
     fun->set_real({inGID, 0, inVID, 0}, -1.0);
     fun->calculate();
-    BOOST_TEST(fun->get_real({outGID, 0, outVID, 0}) == -2.0);
+    CHECK(fun->get_real({outGID, 0, outVID, 0}) == -2.0);
 }
 
 
-BOOST_AUTO_TEST_CASE(vector_sum_standalone)
+TEST_CASE("vector_sum_standalone")
 {
     constexpr int inputCount = 3;
     constexpr auto numericType = cosim::variable_type::integer;
@@ -85,15 +86,15 @@ BOOST_AUTO_TEST_CASE(vector_sum_standalone)
 
     const auto fun = type.instantiate(params);
     const auto funDesc = fun->description();
-    BOOST_TEST_REQUIRE(funDesc.io_groups.size() == 2);
-    BOOST_TEST_REQUIRE(funDesc.io_groups[0].ios.size() == 1);
-    BOOST_TEST_REQUIRE(funDesc.io_groups[1].ios.size() == 1);
-    BOOST_TEST(std::get<int>(funDesc.io_groups[0].count) == inputCount);
-    BOOST_TEST(std::get<int>(funDesc.io_groups[1].count) == 1);
-    BOOST_TEST(std::get<cosim::variable_type>(funDesc.io_groups[0].ios[0].type) == numericType);
-    BOOST_TEST(std::get<cosim::variable_type>(funDesc.io_groups[1].ios[0].type) == numericType);
-    BOOST_TEST(std::get<int>(funDesc.io_groups[0].ios[0].count) == dimension);
-    BOOST_TEST(std::get<int>(funDesc.io_groups[1].ios[0].count) == dimension);
+    REQUIRE(funDesc.io_groups.size() == 2);
+    REQUIRE(funDesc.io_groups[0].ios.size() == 1);
+    REQUIRE(funDesc.io_groups[1].ios.size() == 1);
+    CHECK(std::get<int>(funDesc.io_groups[0].count) == inputCount);
+    CHECK(std::get<int>(funDesc.io_groups[1].count) == 1);
+    CHECK(std::get<cosim::variable_type>(funDesc.io_groups[0].ios[0].type) == numericType);
+    CHECK(std::get<cosim::variable_type>(funDesc.io_groups[1].ios[0].type) == numericType);
+    CHECK(std::get<int>(funDesc.io_groups[0].ios[0].count) == dimension);
+    CHECK(std::get<int>(funDesc.io_groups[1].ios[0].count) == dimension);
 
     const auto [inGID, inVID] = find_io(funDesc, "in");
     const auto [outGID, outVID] = find_io(funDesc, "out");
@@ -104,12 +105,12 @@ BOOST_AUTO_TEST_CASE(vector_sum_standalone)
     fun->set_integer({inGID, 2, inVID, 0}, 7);
     fun->set_integer({inGID, 2, inVID, 1}, 11);
     fun->calculate();
-    BOOST_TEST(fun->get_integer({outGID, 0, outVID, 0}) == 11);
-    BOOST_TEST(fun->get_integer({outGID, 0, outVID, 1}) == 18);
+    CHECK(fun->get_integer({outGID, 0, outVID, 0}) == 11);
+    CHECK(fun->get_integer({outGID, 0, outVID, 1}) == 18);
 }
 
 
-BOOST_AUTO_TEST_CASE(function_in_execution)
+TEST_CASE("function_in_execution")
 {
     // The system simulated here looks like this:
     //
@@ -192,7 +193,7 @@ BOOST_AUTO_TEST_CASE(function_in_execution)
 
     // Run simulation and verify results
     auto success = exe.simulate_until(stopTime);
-    BOOST_TEST_REQUIRE(success);
+    REQUIRE(success);
 
     auto outputs = std::vector<double>(bufferSize);
     auto steps = std::vector<cosim::step_number>(bufferSize);
@@ -209,15 +210,15 @@ BOOST_AUTO_TEST_CASE(function_in_execution)
     constexpr auto midpoint1 =
         (startTime.time_since_epoch() + event1Time.time_since_epoch()) /
         (2 * stepSize);
-    BOOST_TEST(outputs.at(midpoint1) == 1.0); // Result when input is 0.0
+    CHECK(outputs.at(midpoint1) == 1.0); // Result when input is 0.0
 
     constexpr auto midpoint2 =
         (event1Time.time_since_epoch() + event2Time.time_since_epoch()) /
         (2 * stepSize);
-    BOOST_TEST(outputs.at(midpoint2) == 21.0); // Result when input is 10.0
+    CHECK(outputs.at(midpoint2) == 21.0); // Result when input is 10.0
 
     constexpr auto midpoint3 =
         (event2Time.time_since_epoch() + stopTime.time_since_epoch()) /
         (2 * stepSize);
-    BOOST_TEST(outputs.at(midpoint3) == -19.0); // Result when input is -10.0
+    CHECK(outputs.at(midpoint3) == -19.0); // Result when input is -10.0
 }

--- a/tests/orchestration_unittest.cpp
+++ b/tests/orchestration_unittest.cpp
@@ -1,15 +1,16 @@
-#define BOOST_TEST_MODULE orchestration.hpp unittests
+
 #include <cosim/fs_portability.hpp>
 #include <cosim/orchestration.hpp>
 #include <cosim/uri.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 
-BOOST_AUTO_TEST_CASE(file_uri_sub_resolver_absolute_path_test)
+TEST_CASE("file_uri_sub_resolver_absolute_path_test")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
     const auto path = cosim::filesystem::path(testDataDir) / "fmi2" / "Clock.fmu";
     const auto uri = cosim::path_to_file_uri(path);
 
@@ -17,14 +18,14 @@ BOOST_AUTO_TEST_CASE(file_uri_sub_resolver_absolute_path_test)
     resolver.add_sub_resolver(std::make_shared<cosim::fmu_file_uri_sub_resolver>());
 
     auto model = resolver.lookup_model(uri);
-    BOOST_TEST(model->description()->name == "Clock");
+    CHECK(model->description()->name == "Clock");
 }
 
 
-BOOST_AUTO_TEST_CASE(file_uri_sub_resolver_relative_path_test)
+TEST_CASE("file_uri_sub_resolver_relative_path_test")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
     const auto basePath = cosim::filesystem::path(testDataDir) / "some_base";
     const auto baseUri = cosim::path_to_file_uri(basePath);
 
@@ -32,5 +33,5 @@ BOOST_AUTO_TEST_CASE(file_uri_sub_resolver_relative_path_test)
     resolver.add_sub_resolver(std::make_shared<cosim::fmu_file_uri_sub_resolver>());
 
     auto model = resolver.lookup_model(baseUri, "fmi2/Clock.fmu");
-    BOOST_TEST(model->description()->name == "Clock");
+    CHECK(model->description()->name == "Clock");
 }

--- a/tests/proxyfmu_library_unittest.cpp
+++ b/tests/proxyfmu_library_unittest.cpp
@@ -1,6 +1,7 @@
-#define BOOST_TEST_MODULE proxyfmu_library unittests
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
 #include <proxyfmu/client/proxy_fmu.hpp>
 
 using namespace proxyfmu;
@@ -12,15 +13,15 @@ namespace
 void test(fmu& fmu)
 {
     const auto d = fmu.get_model_description();
-    BOOST_TEST(d.modelName == "no.viproma.demo.identity");
-    BOOST_TEST(d.description ==
+    CHECK(d.modelName == "no.viproma.demo.identity");
+    CHECK(d.description ==
         "Has one input and one output of each type, and outputs are always set equal to inputs");
-    BOOST_TEST(d.author == "Lars Tandle Kyllingstad");
+    CHECK(d.author == "Lars Tandle Kyllingstad");
 
     auto slave = fmu.new_instance("instance");
-    BOOST_REQUIRE(slave->setup_experiment());
-    BOOST_REQUIRE(slave->enter_initialization_mode());
-    BOOST_REQUIRE(slave->exit_initialization_mode());
+    REQUIRE(slave->setup_experiment());
+    REQUIRE(slave->enter_initialization_mode());
+    REQUIRE(slave->exit_initialization_mode());
 
     std::vector<value_ref> vr{0};
 
@@ -45,12 +46,12 @@ void test(fmu& fmu)
         slave->get_boolean(vr, booleanRef);
         slave->get_string(vr, stringRef);
 
-        BOOST_TEST(realVal[0] == realRef[0]);
-        BOOST_TEST(integerVal[0] == integerRef[0]);
-        BOOST_TEST(booleanVal[0] == booleanRef[0]);
-        BOOST_TEST(stringVal[0] == stringRef[0]);
+        CHECK(realVal[0] == realRef[0]);
+        CHECK(integerVal[0] == integerRef[0]);
+        CHECK(booleanVal[0] == booleanRef[0]);
+        CHECK(stringVal[0] == stringRef[0]);
 
-        BOOST_REQUIRE(slave->step(t, dt));
+        REQUIRE(slave->step(t, dt));
 
         realVal[0] += 1.0;
         integerVal[0] += 1;
@@ -65,26 +66,26 @@ void test(fmu& fmu)
         t += dt;
     }
 
-    BOOST_REQUIRE(slave->terminate());
+    REQUIRE(slave->terminate());
     slave->freeInstance();
 }
 
 } // namespace
 
-BOOST_AUTO_TEST_CASE(proxyfmu_fmi_test_identity)
+TEST_CASE("proxyfmu_fmi_test_identity")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
 
     auto fmuPath = proxyfmu::filesystem::path(testDataDir) / "fmi1" / "identity.fmu";
     auto fmu = loadFmu(fmuPath);
     test(*fmu);
 }
 
-BOOST_AUTO_TEST_CASE(proxyfmu_client_test_identity)
+TEST_CASE("proxyfmu_client_test_identity")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
 
     auto fmuPath = proxyfmu::filesystem::path(testDataDir) / "fmi1" / "identity.fmu";
     auto fmu = client::proxy_fmu(fmuPath);

--- a/tests/scenario_parser_unittest.cpp
+++ b/tests/scenario_parser_unittest.cpp
@@ -15,10 +15,6 @@
 namespace
 {
 
-// Defines the tolerance for the comparison in percentage units.
-// See https://www.boost.org/doc/libs/1_65_0/libs/test/doc/html/CHECK/utf_reference/testing_tool_ref/assertion_boost_level_close.html
-constexpr double tolerance = 0.0001;
-
 constexpr cosim::time_point startTime = cosim::to_time_point(0.0);
 constexpr cosim::time_point endTime = cosim::to_time_point(1.1);
 constexpr cosim::duration stepSize = cosim::to_duration(0.1);

--- a/tests/scenario_parser_unittest.cpp
+++ b/tests/scenario_parser_unittest.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_MODULE scenario_parser.hpp unittests
 
 #include "mock_slave.hpp"
 
@@ -7,7 +6,8 @@
 #include <cosim/manipulator.hpp>
 #include <cosim/observer/time_series_observer.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <exception>
 #include <memory>
@@ -16,7 +16,7 @@ namespace
 {
 
 // Defines the tolerance for the comparison in percentage units.
-// See https://www.boost.org/doc/libs/1_65_0/libs/test/doc/html/boost_test/utf_reference/testing_tool_ref/assertion_boost_level_close.html
+// See https://www.boost.org/doc/libs/1_65_0/libs/test/doc/html/CHECK/utf_reference/testing_tool_ref/assertion_boost_level_close.html
 constexpr double tolerance = 0.0001;
 
 constexpr cosim::time_point startTime = cosim::to_time_point(0.0);
@@ -54,7 +54,7 @@ void test(const cosim::filesystem::path& scenarioFile)
     scenarioManager->load_scenario(scenarioFile, startTime);
 
     auto simResult = execution.simulate_until(endTime);
-    BOOST_REQUIRE(simResult);
+    REQUIRE(simResult);
 
     const int numSamples = 11;
     double realInputValues[numSamples];
@@ -71,7 +71,7 @@ void test(const cosim::filesystem::path& scenarioFile)
         gsl::make_span(realInputValues, numSamples),
         gsl::make_span(steps, numSamples),
         gsl::make_span(times, numSamples));
-    BOOST_CHECK(samplesRead == 11);
+    CHECK(samplesRead == 11);
     samplesRead = observer->get_real_samples(
         simIndex,
         mock_slave::real_out_reference,
@@ -79,7 +79,7 @@ void test(const cosim::filesystem::path& scenarioFile)
         gsl::make_span(realOutputValues, numSamples),
         gsl::make_span(steps, numSamples),
         gsl::make_span(times, numSamples));
-    BOOST_CHECK(samplesRead == 11);
+    CHECK(samplesRead == 11);
     samplesRead = observer->get_integer_samples(
         simIndex,
         mock_slave::integer_in_reference,
@@ -87,7 +87,7 @@ void test(const cosim::filesystem::path& scenarioFile)
         gsl::make_span(intInputValues, numSamples),
         gsl::make_span(steps, numSamples),
         gsl::make_span(times, numSamples));
-    BOOST_CHECK(samplesRead == 11);
+    CHECK(samplesRead == 11);
     samplesRead = observer->get_integer_samples(
         simIndex,
         mock_slave::integer_out_reference,
@@ -95,7 +95,7 @@ void test(const cosim::filesystem::path& scenarioFile)
         gsl::make_span(intOutputValues, numSamples),
         gsl::make_span(steps, numSamples),
         gsl::make_span(times, numSamples));
-    BOOST_CHECK(samplesRead == 11);
+    CHECK(samplesRead == 11);
 
     double expectedRealInputs[] = {0.0, 0.0, 0.0, 0.0, 0.0, 1.001, 1.001, 1.001, 1.001, 1.001, 0.0};
     double expectedRealOutputs[] = {1.234, 1.234, -1.0, 1.234, 1.234, 2.235, 2.235, 2.235, 2.235, 2.235, 1.234};
@@ -103,27 +103,27 @@ void test(const cosim::filesystem::path& scenarioFile)
     int expectedIntOutputs[] = {2, 2, 2, 2, 2, 2, 2, 4, 5, 5, 2};
 
     for (size_t i = 0; i < samplesRead; i++) {
-        BOOST_CHECK_CLOSE(realInputValues[i], expectedRealInputs[i], tolerance);
-        BOOST_CHECK_CLOSE(realOutputValues[i], expectedRealOutputs[i], tolerance);
-        BOOST_CHECK(intInputValues[i] == expectedIntInputs[i]);
-        BOOST_CHECK(intOutputValues[i] == expectedIntOutputs[i]);
+        CHECK(realInputValues[i] == Approx(expectedRealInputs[i]));
+        CHECK(realOutputValues[i] == Approx(expectedRealOutputs[i]));
+        CHECK(intInputValues[i] == expectedIntInputs[i]);
+        CHECK(intOutputValues[i] == expectedIntOutputs[i]);
     }
 }
 
 } // namespace
 
-BOOST_AUTO_TEST_CASE(json_test)
+TEST_CASE("json_test")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
 
     test(cosim::filesystem::path(testDataDir) / "scenarios" / "scenario1.json");
 }
 
-BOOST_AUTO_TEST_CASE(yaml_test)
+TEST_CASE("yaml_test")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
 
     test(cosim::filesystem::path(testDataDir) / "scenarios" / "scenario1.yml");
 }

--- a/tests/ssp_loader_unittest.cpp
+++ b/tests/ssp_loader_unittest.cpp
@@ -1,21 +1,18 @@
-#define BOOST_TEST_MODULE ssp_loader.hpp unittests
+
 #include <cosim/algorithm/fixed_step_algorithm.hpp>
 #include <cosim/fs_portability.hpp>
 #include <cosim/log/simple.hpp>
 #include <cosim/observer/last_value_observer.hpp>
 #include <cosim/ssp/ssp_loader.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <algorithm>
 
 
 namespace
 {
-
-// Defines the tolerance for the comparison in percentage units.
-// See https://www.boost.org/doc/libs/1_65_0/libs/test/doc/html/boost_test/utf_reference/testing_tool_ref/assertion_boost_level_close.html
-constexpr double tolerance = 0.0001;
 
 void common_demo_case_tests(const cosim::ssp_configuration& config)
 {
@@ -25,14 +22,14 @@ void common_demo_case_tests(const cosim::ssp_configuration& config)
         config.system_structure,
         config.parameter_sets.at(""));
 
-    BOOST_REQUIRE(entityMaps.simulators.size() == 2);
-    BOOST_REQUIRE(entityMaps.simulators.count("CraneController") == 1);
+    REQUIRE(entityMaps.simulators.size() == 2);
+    REQUIRE(entityMaps.simulators.count("CraneController") == 1);
     const auto knuckleBoomCrane = entityMaps.simulators.at("KnuckleBoomCrane");
 
     auto obs = std::make_shared<cosim::last_value_observer>();
     execution.add_observer(obs);
     auto result = execution.simulate_until(cosim::to_time_point(1e-3));
-    BOOST_REQUIRE(result);
+    REQUIRE(result);
 
     double realValue = -1.0;
     const auto reference =
@@ -40,25 +37,25 @@ void common_demo_case_tests(const cosim::ssp_configuration& config)
     obs->get_real(knuckleBoomCrane, gsl::make_span(&reference, 1), gsl::make_span(&realValue, 1));
 
     double magicNumberFromSsdFile = 0.005;
-    BOOST_CHECK_CLOSE(realValue, magicNumberFromSsdFile, tolerance);
+    CHECK(realValue == Approx(magicNumberFromSsdFile));
 
     const auto reference2 =
         config.system_structure.get_variable_description({"KnuckleBoomCrane", "mt0_init"}).reference;
     obs->get_real(knuckleBoomCrane, gsl::make_span(&reference2, 1), gsl::make_span(&realValue, 1));
 
     magicNumberFromSsdFile = 69.0;
-    BOOST_CHECK_CLOSE(realValue, magicNumberFromSsdFile, tolerance);
+    CHECK(realValue == Approx(magicNumberFromSsdFile));
 }
 
 } // namespace
 
-BOOST_AUTO_TEST_CASE(basic_test)
+TEST_CASE("basic_test")
 {
     cosim::log::setup_simple_console_logging();
     cosim::log::set_global_output_level(cosim::log::info);
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
     cosim::filesystem::path sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo";
 
     cosim::ssp_loader loader;
@@ -67,13 +64,13 @@ BOOST_AUTO_TEST_CASE(basic_test)
     common_demo_case_tests(config);
 }
 
-BOOST_AUTO_TEST_CASE(no_algorithm_test)
+TEST_CASE("no_algorithm_test")
 {
     cosim::log::setup_simple_console_logging();
     cosim::log::set_global_output_level(cosim::log::info);
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
     cosim::filesystem::path sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "no_algorithm_element";
 
     cosim::ssp_loader loader;
@@ -81,18 +78,18 @@ BOOST_AUTO_TEST_CASE(no_algorithm_test)
     config.algorithm = std::make_unique<cosim::fixed_step_algorithm>(cosim::to_duration(1e-4));
 
     double startTimeDefinedInSsp = 5.0;
-    BOOST_CHECK_CLOSE(cosim::to_double_time_point(config.start_time), startTimeDefinedInSsp, tolerance);
+    CHECK(cosim::to_double_time_point(config.start_time) == Approx(startTimeDefinedInSsp));
 
     common_demo_case_tests(config);
 }
 
-BOOST_AUTO_TEST_CASE(ssp_archive)
+TEST_CASE("ssp_archive")
 {
     cosim::log::setup_simple_console_logging();
     cosim::log::set_global_output_level(cosim::log::info);
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
     const auto sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "demo.ssp";
 
     cosim::ssp_loader loader;
@@ -100,26 +97,26 @@ BOOST_AUTO_TEST_CASE(ssp_archive)
     common_demo_case_tests(config);
 }
 
-BOOST_AUTO_TEST_CASE(ssp_archive_multiple_ssd)
+TEST_CASE("ssp_archive_multiple_ssd")
 {
     cosim::log::setup_simple_console_logging();
     cosim::log::set_global_output_level(cosim::log::info);
 
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
     const auto sspFile = cosim::filesystem::path(testDataDir) / "ssp" / "demo" / "demo.ssp";
 
     cosim::ssp_loader loader;
     loader.set_ssd_file_name("SystemStructure2");
     const auto config = loader.load(sspFile);
     const auto entities = config.system_structure.entities();
-    BOOST_REQUIRE(std::distance(entities.begin(), entities.end()) == 1);
+    REQUIRE(std::distance(entities.begin(), entities.end()) == 1);
 }
 
-BOOST_AUTO_TEST_CASE(ssp_linear_transformation_test)
+TEST_CASE("ssp_linear_transformation_test")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
     const auto sspDir = cosim::filesystem::path(testDataDir) / "ssp" / "linear_transformation";
 
     cosim::ssp_loader loader;
@@ -143,7 +140,7 @@ BOOST_AUTO_TEST_CASE(ssp_linear_transformation_test)
     const auto v1Ref =
         config.system_structure.get_variable_description({"identity1", "realOut"}).reference;
     observer->get_real(slave1, gsl::make_span(&v1Ref, 1), gsl::make_span(&initialValue, 1));
-    BOOST_REQUIRE_CLOSE(initialValue, 2.0, tolerance);
+    REQUIRE(initialValue == Approx(2.0));
 
     double transformedValue;
     const auto slave2 = entityMaps.simulators.at("identity2");
@@ -154,13 +151,13 @@ BOOST_AUTO_TEST_CASE(ssp_linear_transformation_test)
     double offset = 50;
     double factor = 1.3;
     double target = factor * initialValue + offset;
-    BOOST_REQUIRE_CLOSE(transformedValue, target, tolerance);
+    REQUIRE(transformedValue == Approx(target));
 }
 
-BOOST_AUTO_TEST_CASE(ssp_multiple_parameter_sets_test)
+TEST_CASE("ssp_multiple_parameter_sets_test")
 {
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(testDataDir != nullptr);
+    REQUIRE(testDataDir != nullptr);
     const auto sspDir = cosim::filesystem::path(testDataDir) / "ssp" / "linear_transformation";
 
     cosim::ssp_loader loader;
@@ -184,5 +181,5 @@ BOOST_AUTO_TEST_CASE(ssp_multiple_parameter_sets_test)
     const auto v1Ref =
         config.system_structure.get_variable_description({"identity1", "realOut"}).reference;
     observer->get_real(slave1, gsl::make_span(&v1Ref, 1), gsl::make_span(&initialValue, 1));
-    BOOST_REQUIRE_CLOSE(initialValue, 4.0, tolerance);
+    REQUIRE(initialValue == Approx(4.0));
 }

--- a/tests/time_unittest.cpp
+++ b/tests/time_unittest.cpp
@@ -1,10 +1,11 @@
-#define BOOST_TEST_MODULE time.hpp unittests
+
 #include <cosim/time.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 
-BOOST_AUTO_TEST_CASE(to_double_time_point_duration_addition)
+TEST_CASE("to_double_time_point_duration_addition")
 {
     constexpr cosim::duration time[] = {
         cosim::duration(0),
@@ -20,21 +21,18 @@ BOOST_AUTO_TEST_CASE(to_double_time_point_duration_addition)
     for (const auto t : time) {
         for (const auto dt : time) {
             const auto t1 = cosim::time_point{t};
-            BOOST_TEST(cosim::to_double_time_point(t1) + cosim::to_double_duration(dt, t1) == cosim::to_double_time_point(t1 + dt));
+            CHECK(cosim::to_double_time_point(t1) + cosim::to_double_duration(dt, t1) == cosim::to_double_time_point(t1 + dt));
         }
     }
 }
 
-BOOST_TEST_DONT_PRINT_LOG_VALUE(cosim::duration)
-BOOST_TEST_DONT_PRINT_LOG_VALUE(cosim::time_point)
-
-BOOST_AUTO_TEST_CASE(to_time_point_duration_addition)
+TEST_CASE("to_time_point_duration_addition")
 {
     constexpr double time[] = {0.0, 1e-9, 1e-6, 1e-3, 1.0, 1e3, 1e6, 1e9};
 
     for (const auto t1 : time) {
         for (const auto dt : time) {
-            BOOST_TEST(cosim::to_time_point(t1) + cosim::to_duration(dt, t1) == cosim::to_time_point(t1 + dt));
+            CHECK(cosim::to_time_point(t1) + cosim::to_duration(dt, t1) == cosim::to_time_point(t1 + dt));
         }
     }
 }

--- a/tests/uri_unittest.cpp
+++ b/tests/uri_unittest.cpp
@@ -1,112 +1,113 @@
-#define BOOST_TEST_MODULE uri.hpp unittests
+
 #include <cosim/uri.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <stdexcept>
 
 using namespace cosim;
 
 
-BOOST_AUTO_TEST_CASE(uri_parser)
+TEST_CASE("uri_parser")
 {
     const uri emptyURI;
-    BOOST_TEST(emptyURI == uri(""));
-    BOOST_TEST(emptyURI == uri(std::nullopt, std::nullopt, ""));
-    BOOST_TEST(emptyURI.view().empty());
-    BOOST_TEST(!emptyURI.scheme().has_value());
-    BOOST_TEST(!emptyURI.authority().has_value());
-    BOOST_TEST(emptyURI.path().empty());
-    BOOST_TEST(!emptyURI.query().has_value());
-    BOOST_TEST(!emptyURI.fragment().has_value());
-    BOOST_TEST(emptyURI.empty());
+    CHECK(emptyURI == uri(""));
+    CHECK(emptyURI == uri(std::nullopt, std::nullopt, ""));
+    CHECK(emptyURI.view().empty());
+    CHECK(!emptyURI.scheme().has_value());
+    CHECK(!emptyURI.authority().has_value());
+    CHECK(emptyURI.path().empty());
+    CHECK(!emptyURI.query().has_value());
+    CHECK(!emptyURI.fragment().has_value());
+    CHECK(emptyURI.empty());
 
     /*not const*/ auto httpURI = uri("http://user@example.com:1234/foo/bar?q=uux#frag");
-    BOOST_TEST(httpURI.view() == "http://user@example.com:1234/foo/bar?q=uux#frag");
-    BOOST_REQUIRE(httpURI.scheme().has_value());
-    BOOST_TEST(*httpURI.scheme() == "http");
-    BOOST_REQUIRE(httpURI.authority().has_value());
-    BOOST_TEST(*httpURI.authority() == "user@example.com:1234");
-    BOOST_TEST(httpURI.path() == "/foo/bar");
-    BOOST_REQUIRE(httpURI.query().has_value());
-    BOOST_TEST(*httpURI.query() == "q=uux");
-    BOOST_REQUIRE(httpURI.fragment().has_value());
-    BOOST_TEST(*httpURI.fragment() == "frag");
-    BOOST_TEST(!httpURI.empty());
+    CHECK(httpURI.view() == "http://user@example.com:1234/foo/bar?q=uux#frag");
+    REQUIRE(httpURI.scheme().has_value());
+    CHECK(*httpURI.scheme() == "http");
+    REQUIRE(httpURI.authority().has_value());
+    CHECK(*httpURI.authority() == "user@example.com:1234");
+    CHECK(httpURI.path() == "/foo/bar");
+    REQUIRE(httpURI.query().has_value());
+    CHECK(*httpURI.query() == "q=uux");
+    REQUIRE(httpURI.fragment().has_value());
+    CHECK(*httpURI.fragment() == "frag");
+    CHECK(!httpURI.empty());
 
     const auto httpURI2 = uri("http", "user@example.com:1234", "/foo/bar", "q=uux", "frag");
-    BOOST_TEST(httpURI2.view() == "http://user@example.com:1234/foo/bar?q=uux#frag");
-    BOOST_REQUIRE(httpURI2.scheme().has_value());
-    BOOST_TEST(*httpURI2.scheme() == "http");
-    BOOST_REQUIRE(httpURI2.authority().has_value());
-    BOOST_TEST(*httpURI2.authority() == "user@example.com:1234");
-    BOOST_TEST(httpURI2.path() == "/foo/bar");
-    BOOST_REQUIRE(httpURI2.query().has_value());
-    BOOST_TEST(*httpURI2.query() == "q=uux");
-    BOOST_REQUIRE(httpURI2.fragment().has_value());
-    BOOST_TEST(*httpURI2.fragment() == "frag");
-    BOOST_TEST(!httpURI2.empty());
+    CHECK(httpURI2.view() == "http://user@example.com:1234/foo/bar?q=uux#frag");
+    REQUIRE(httpURI2.scheme().has_value());
+    CHECK(*httpURI2.scheme() == "http");
+    REQUIRE(httpURI2.authority().has_value());
+    CHECK(*httpURI2.authority() == "user@example.com:1234");
+    CHECK(httpURI2.path() == "/foo/bar");
+    REQUIRE(httpURI2.query().has_value());
+    CHECK(*httpURI2.query() == "q=uux");
+    REQUIRE(httpURI2.fragment().has_value());
+    CHECK(*httpURI2.fragment() == "frag");
+    CHECK(!httpURI2.empty());
 
     const auto fileURI = uri("file:///foo/bar#frag?q=uux");
-    BOOST_TEST(fileURI.view() == "file:///foo/bar#frag?q=uux");
-    BOOST_REQUIRE(fileURI.scheme().has_value());
-    BOOST_TEST(*fileURI.scheme() == "file");
-    BOOST_REQUIRE(fileURI.authority().has_value());
-    BOOST_TEST(fileURI.authority()->empty());
-    BOOST_TEST(fileURI.path() == "/foo/bar");
-    BOOST_TEST(!fileURI.query().has_value());
-    BOOST_REQUIRE(fileURI.fragment().has_value());
-    BOOST_TEST(*fileURI.fragment() == "frag?q=uux");
-    BOOST_TEST(!fileURI.empty());
+    CHECK(fileURI.view() == "file:///foo/bar#frag?q=uux");
+    REQUIRE(fileURI.scheme().has_value());
+    CHECK(*fileURI.scheme() == "file");
+    REQUIRE(fileURI.authority().has_value());
+    CHECK(fileURI.authority()->empty());
+    CHECK(fileURI.path() == "/foo/bar");
+    CHECK(!fileURI.query().has_value());
+    REQUIRE(fileURI.fragment().has_value());
+    CHECK(*fileURI.fragment() == "frag?q=uux");
+    CHECK(!fileURI.empty());
 
     const auto mailtoURI = uri("mailto:user@example.com");
-    BOOST_TEST(mailtoURI.view() == "mailto:user@example.com");
-    BOOST_REQUIRE(mailtoURI.scheme().has_value());
-    BOOST_TEST(*mailtoURI.scheme() == "mailto");
-    BOOST_TEST(!mailtoURI.authority().has_value());
-    BOOST_TEST(mailtoURI.path() == "user@example.com");
-    BOOST_TEST(!mailtoURI.query().has_value());
-    BOOST_TEST(!mailtoURI.fragment().has_value());
-    BOOST_TEST(!mailtoURI.empty());
+    CHECK(mailtoURI.view() == "mailto:user@example.com");
+    REQUIRE(mailtoURI.scheme().has_value());
+    CHECK(*mailtoURI.scheme() == "mailto");
+    CHECK(!mailtoURI.authority().has_value());
+    CHECK(mailtoURI.path() == "user@example.com");
+    CHECK(!mailtoURI.query().has_value());
+    CHECK(!mailtoURI.fragment().has_value());
+    CHECK(!mailtoURI.empty());
 
     const auto urnURI = uri("urn:foo:bar:baz");
-    BOOST_TEST(urnURI.view() == "urn:foo:bar:baz");
-    BOOST_REQUIRE(urnURI.scheme().has_value());
-    BOOST_TEST(*urnURI.scheme() == "urn");
-    BOOST_TEST(!urnURI.authority().has_value());
-    BOOST_TEST(urnURI.path() == "foo:bar:baz");
-    BOOST_TEST(!urnURI.query().has_value());
-    BOOST_TEST(!urnURI.fragment().has_value());
-    BOOST_TEST(!urnURI.empty());
+    CHECK(urnURI.view() == "urn:foo:bar:baz");
+    REQUIRE(urnURI.scheme().has_value());
+    CHECK(*urnURI.scheme() == "urn");
+    CHECK(!urnURI.authority().has_value());
+    CHECK(urnURI.path() == "foo:bar:baz");
+    CHECK(!urnURI.query().has_value());
+    CHECK(!urnURI.fragment().has_value());
+    CHECK(!urnURI.empty());
 }
 
 
-BOOST_AUTO_TEST_CASE(uri_copy_and_move)
+TEST_CASE("uri_copy_and_move")
 {
     auto orig = uri("http://user@example.com:1234/foo/bar?q=uux#frag");
     const auto copy = orig;
     const auto move = std::move(orig);
     orig = uri();
 
-    BOOST_REQUIRE(copy.scheme().has_value());
-    BOOST_TEST(*copy.scheme() == "http");
-    BOOST_REQUIRE(copy.authority().has_value());
-    BOOST_TEST(*copy.authority() == "user@example.com:1234");
-    BOOST_TEST(copy.path() == "/foo/bar");
-    BOOST_REQUIRE(copy.query().has_value());
-    BOOST_TEST(*copy.query() == "q=uux");
-    BOOST_REQUIRE(copy.fragment().has_value());
-    BOOST_TEST(*copy.fragment() == "frag");
+    REQUIRE(copy.scheme().has_value());
+    CHECK(*copy.scheme() == "http");
+    REQUIRE(copy.authority().has_value());
+    CHECK(*copy.authority() == "user@example.com:1234");
+    CHECK(copy.path() == "/foo/bar");
+    REQUIRE(copy.query().has_value());
+    CHECK(*copy.query() == "q=uux");
+    REQUIRE(copy.fragment().has_value());
+    CHECK(*copy.fragment() == "frag");
 
-    BOOST_REQUIRE(move.scheme().has_value());
-    BOOST_TEST(*move.scheme() == "http");
-    BOOST_REQUIRE(move.authority().has_value());
-    BOOST_TEST(*move.authority() == "user@example.com:1234");
-    BOOST_TEST(move.path() == "/foo/bar");
-    BOOST_REQUIRE(move.query().has_value());
-    BOOST_TEST(*move.query() == "q=uux");
-    BOOST_REQUIRE(move.fragment().has_value());
-    BOOST_TEST(*move.fragment() == "frag");
+    REQUIRE(move.scheme().has_value());
+    CHECK(*move.scheme() == "http");
+    REQUIRE(move.authority().has_value());
+    CHECK(*move.authority() == "user@example.com:1234");
+    CHECK(move.path() == "/foo/bar");
+    REQUIRE(move.query().has_value());
+    CHECK(*move.query() == "q=uux");
+    REQUIRE(move.fragment().has_value());
+    CHECK(*move.fragment() == "frag");
 
     // Special case: Short strings which may be affected by the small-string
     // optimisation (see issue #361)
@@ -115,110 +116,110 @@ BOOST_AUTO_TEST_CASE(uri_copy_and_move)
     const auto smallMove = std::move(small);
     small = uri();
 
-    BOOST_TEST(smallCopy.path() == "x");
-    BOOST_TEST(smallMove.path() == "x");
+    CHECK(smallCopy.path() == "x");
+    CHECK(smallMove.path() == "x");
 }
 
 
-BOOST_AUTO_TEST_CASE(uri_comparison)
+TEST_CASE("uri_comparison")
 {
     const auto httpURI = uri("http://user@example.com:1234/foo/bar?q=uux#frag");
     const auto fileURI = uri("file:///foo/bar#frag?q=uux");
 
-    BOOST_TEST(httpURI == httpURI);
-    BOOST_TEST(httpURI == "http://user@example.com:1234/foo/bar?q=uux#frag");
-    BOOST_TEST("http://user@example.com:1234/foo/bar?q=uux#frag" == httpURI);
-    BOOST_TEST(httpURI != fileURI);
-    BOOST_TEST(fileURI != httpURI);
-    BOOST_TEST(fileURI != "http://user@example.com:1234/foo/bar?q=uux#frag");
-    BOOST_TEST("http://user@example.com:1234/foo/bar?q=uux#frag" != fileURI);
+    CHECK(httpURI == httpURI);
+    CHECK(httpURI == "http://user@example.com:1234/foo/bar?q=uux#frag");
+    CHECK("http://user@example.com:1234/foo/bar?q=uux#frag" == httpURI);
+    CHECK(httpURI != fileURI);
+    CHECK(fileURI != httpURI);
+    CHECK(fileURI != "http://user@example.com:1234/foo/bar?q=uux#frag");
+    CHECK("http://user@example.com:1234/foo/bar?q=uux#frag" != fileURI);
 }
 
 
 // URI reference resolution examples from RFC 3986
-BOOST_AUTO_TEST_CASE(uri_resolution)
+TEST_CASE("uri_resolution")
 {
     const auto baseURI = uri("http://a/b/c/d;p?q");
-    BOOST_TEST(resolve_reference(baseURI, "g:h") == "g:h");
-    BOOST_TEST(resolve_reference(baseURI, "g") == "http://a/b/c/g");
-    BOOST_TEST(resolve_reference(baseURI, "./g") == "http://a/b/c/g");
-    BOOST_TEST(resolve_reference(baseURI, "g/") == "http://a/b/c/g/");
-    BOOST_TEST(resolve_reference(baseURI, "/g") == "http://a/g");
-    BOOST_TEST(resolve_reference(baseURI, "//g") == "http://g");
-    BOOST_TEST(resolve_reference(baseURI, "?y") == "http://a/b/c/d;p?y");
-    BOOST_TEST(resolve_reference(baseURI, "g?y") == "http://a/b/c/g?y");
-    BOOST_TEST(resolve_reference(baseURI, "#s") == "http://a/b/c/d;p?q#s");
-    BOOST_TEST(resolve_reference(baseURI, "g#s") == "http://a/b/c/g#s");
-    BOOST_TEST(resolve_reference(baseURI, "g?y#s") == "http://a/b/c/g?y#s");
-    BOOST_TEST(resolve_reference(baseURI, ";x") == "http://a/b/c/;x");
-    BOOST_TEST(resolve_reference(baseURI, "g;x") == "http://a/b/c/g;x");
-    BOOST_TEST(resolve_reference(baseURI, "g;x?y#s") == "http://a/b/c/g;x?y#s");
-    BOOST_TEST(resolve_reference(baseURI, "") == "http://a/b/c/d;p?q");
-    BOOST_TEST(resolve_reference(baseURI, ".") == "http://a/b/c/");
-    BOOST_TEST(resolve_reference(baseURI, "./") == "http://a/b/c/");
-    BOOST_TEST(resolve_reference(baseURI, "..") == "http://a/b/");
-    BOOST_TEST(resolve_reference(baseURI, "../") == "http://a/b/");
-    BOOST_TEST(resolve_reference(baseURI, "../g") == "http://a/b/g");
-    BOOST_TEST(resolve_reference(baseURI, "../..") == "http://a/");
-    BOOST_TEST(resolve_reference(baseURI, "../../") == "http://a/");
-    BOOST_TEST(resolve_reference(baseURI, "../../g") == "http://a/g");
+    CHECK(resolve_reference(baseURI, "g:h") == "g:h");
+    CHECK(resolve_reference(baseURI, "g") == "http://a/b/c/g");
+    CHECK(resolve_reference(baseURI, "./g") == "http://a/b/c/g");
+    CHECK(resolve_reference(baseURI, "g/") == "http://a/b/c/g/");
+    CHECK(resolve_reference(baseURI, "/g") == "http://a/g");
+    CHECK(resolve_reference(baseURI, "//g") == "http://g");
+    CHECK(resolve_reference(baseURI, "?y") == "http://a/b/c/d;p?y");
+    CHECK(resolve_reference(baseURI, "g?y") == "http://a/b/c/g?y");
+    CHECK(resolve_reference(baseURI, "#s") == "http://a/b/c/d;p?q#s");
+    CHECK(resolve_reference(baseURI, "g#s") == "http://a/b/c/g#s");
+    CHECK(resolve_reference(baseURI, "g?y#s") == "http://a/b/c/g?y#s");
+    CHECK(resolve_reference(baseURI, ";x") == "http://a/b/c/;x");
+    CHECK(resolve_reference(baseURI, "g;x") == "http://a/b/c/g;x");
+    CHECK(resolve_reference(baseURI, "g;x?y#s") == "http://a/b/c/g;x?y#s");
+    CHECK(resolve_reference(baseURI, "") == "http://a/b/c/d;p?q");
+    CHECK(resolve_reference(baseURI, ".") == "http://a/b/c/");
+    CHECK(resolve_reference(baseURI, "./") == "http://a/b/c/");
+    CHECK(resolve_reference(baseURI, "..") == "http://a/b/");
+    CHECK(resolve_reference(baseURI, "../") == "http://a/b/");
+    CHECK(resolve_reference(baseURI, "../g") == "http://a/b/g");
+    CHECK(resolve_reference(baseURI, "../..") == "http://a/");
+    CHECK(resolve_reference(baseURI, "../../") == "http://a/");
+    CHECK(resolve_reference(baseURI, "../../g") == "http://a/g");
 
-    BOOST_TEST(resolve_reference(baseURI, "../../../g") == "http://a/g");
-    BOOST_TEST(resolve_reference(baseURI, "../../../../g") == "http://a/g");
+    CHECK(resolve_reference(baseURI, "../../../g") == "http://a/g");
+    CHECK(resolve_reference(baseURI, "../../../../g") == "http://a/g");
 
-    BOOST_TEST(resolve_reference(baseURI, "/./g") == "http://a/g");
-    BOOST_TEST(resolve_reference(baseURI, "/../g") == "http://a/g");
-    BOOST_TEST(resolve_reference(baseURI, "g.") == "http://a/b/c/g.");
-    BOOST_TEST(resolve_reference(baseURI, ".g") == "http://a/b/c/.g");
-    BOOST_TEST(resolve_reference(baseURI, "g..") == "http://a/b/c/g..");
-    BOOST_TEST(resolve_reference(baseURI, "..g") == "http://a/b/c/..g");
+    CHECK(resolve_reference(baseURI, "/./g") == "http://a/g");
+    CHECK(resolve_reference(baseURI, "/../g") == "http://a/g");
+    CHECK(resolve_reference(baseURI, "g.") == "http://a/b/c/g.");
+    CHECK(resolve_reference(baseURI, ".g") == "http://a/b/c/.g");
+    CHECK(resolve_reference(baseURI, "g..") == "http://a/b/c/g..");
+    CHECK(resolve_reference(baseURI, "..g") == "http://a/b/c/..g");
 
-    BOOST_TEST(resolve_reference(baseURI, "g?y/./x") == "http://a/b/c/g?y/./x");
-    BOOST_TEST(resolve_reference(baseURI, "g?y/../x") == "http://a/b/c/g?y/../x");
-    BOOST_TEST(resolve_reference(baseURI, "g#s/./x") == "http://a/b/c/g#s/./x");
-    BOOST_TEST(resolve_reference(baseURI, "g#s/../x") == "http://a/b/c/g#s/../x");
+    CHECK(resolve_reference(baseURI, "g?y/./x") == "http://a/b/c/g?y/./x");
+    CHECK(resolve_reference(baseURI, "g?y/../x") == "http://a/b/c/g?y/../x");
+    CHECK(resolve_reference(baseURI, "g#s/./x") == "http://a/b/c/g#s/./x");
+    CHECK(resolve_reference(baseURI, "g#s/../x") == "http://a/b/c/g#s/../x");
 
-    BOOST_TEST(resolve_reference(baseURI, "http:g") == "http:g");
+    CHECK(resolve_reference(baseURI, "http:g") == "http:g");
 }
 
 
-BOOST_AUTO_TEST_CASE(percent_encoding)
+TEST_CASE("percent_encoding")
 {
-    BOOST_TEST(percent_encode(" foo*/123;bar%") == "%20foo%2A%2F123%3Bbar%25");
-    BOOST_TEST(percent_encode(" foo*/123;bar%", "/;") == "%20foo%2A/123;bar%25");
+    CHECK(percent_encode(" foo*/123;bar%") == "%20foo%2A%2F123%3Bbar%25");
+    CHECK(percent_encode(" foo*/123;bar%", "/;") == "%20foo%2A/123;bar%25");
 
-    BOOST_TEST(percent_decode("%20foo%2A%2F123%3Bbar%25") == " foo*/123;bar%");
-    BOOST_TEST(percent_decode("%20foo%2a%2f123%3bbar%25") == " foo*/123;bar%");
-    BOOST_CHECK_THROW(percent_decode("%G0"), std::domain_error);
-    BOOST_CHECK_THROW(percent_decode("%0G"), std::domain_error);
+    CHECK(percent_decode("%20foo%2A%2F123%3Bbar%25") == " foo*/123;bar%");
+    CHECK(percent_decode("%20foo%2a%2f123%3bbar%25") == " foo*/123;bar%");
+    CHECK_THROWS_AS(percent_decode("%G0"), std::domain_error);
+    CHECK_THROWS_AS(percent_decode("%0G"), std::domain_error);
 
-    BOOST_TEST(percent_encode_uri("http", "user name@10.0.0.1:passwd", "/foo/bar baz", "q1=foo bar&q2=baz;q3", "foo bar") == "http://user%20name@10.0.0.1:passwd/foo/bar%20baz?q1=foo%20bar&q2=baz;q3#foo%20bar");
+    CHECK(percent_encode_uri("http", "user name@10.0.0.1:passwd", "/foo/bar baz", "q1=foo bar&q2=baz;q3", "foo bar") == "http://user%20name@10.0.0.1:passwd/foo/bar%20baz?q1=foo%20bar&q2=baz;q3#foo%20bar");
 }
 
 
-BOOST_AUTO_TEST_CASE(file_uri_conversions)
+TEST_CASE("file_uri_conversions")
 {
     // From path to URI
-    BOOST_TEST(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");
-    BOOST_TEST(path_to_file_uri(cosim::filesystem::path()) == "file:");
+    CHECK(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");
+    CHECK(path_to_file_uri(cosim::filesystem::path()) == "file:");
 #ifdef _WIN32
-    BOOST_TEST(path_to_file_uri("\\foo bar\\baz") == "file:///foo%20bar/baz");
-    BOOST_TEST(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");
-    BOOST_TEST(path_to_file_uri("c:\\foo bar\\baz") == "file:///c:/foo%20bar/baz");
+    CHECK(path_to_file_uri("\\foo bar\\baz") == "file:///foo%20bar/baz");
+    CHECK(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");
+    CHECK(path_to_file_uri("c:\\foo bar\\baz") == "file:///c:/foo%20bar/baz");
 #endif
 
     // From URI to path
 #ifdef _WIN32
-    BOOST_TEST(file_uri_to_path("file:///foo%20bar/baz") == "\\foo bar\\baz");
-    BOOST_TEST(file_uri_to_path("file:///c:/foo%20bar/baz") == "c:\\foo bar\\baz");
-    BOOST_TEST(file_uri_to_path("file://localhost/foo%20bar/baz") == "\\foo bar\\baz");
-    BOOST_TEST(file_uri_to_path("file://localhost/c:/foo%20bar/baz") == "c:\\foo bar\\baz");
+    CHECK(file_uri_to_path("file:///foo%20bar/baz") == "\\foo bar\\baz");
+    CHECK(file_uri_to_path("file:///c:/foo%20bar/baz") == "c:\\foo bar\\baz");
+    CHECK(file_uri_to_path("file://localhost/foo%20bar/baz") == "\\foo bar\\baz");
+    CHECK(file_uri_to_path("file://localhost/c:/foo%20bar/baz") == "c:\\foo bar\\baz");
 #else
-    BOOST_TEST(file_uri_to_path("file:///foo%20bar/baz") == "/foo bar/baz");
-    BOOST_TEST(file_uri_to_path("file:///c:/foo%20bar/baz") == "/c:/foo bar/baz");
-    BOOST_TEST(file_uri_to_path("file://localhost/foo%20bar/baz") == "/foo bar/baz");
-    BOOST_TEST(file_uri_to_path("file://localhost/c:/foo%20bar/baz") == "/c:/foo bar/baz");
+    CHECK(file_uri_to_path("file:///foo%20bar/baz") == "/foo bar/baz");
+    CHECK(file_uri_to_path("file:///c:/foo%20bar/baz") == "/c:/foo bar/baz");
+    CHECK(file_uri_to_path("file://localhost/foo%20bar/baz") == "/foo bar/baz");
+    CHECK(file_uri_to_path("file://localhost/c:/foo%20bar/baz") == "/c:/foo bar/baz");
 #endif
-    BOOST_CHECK_THROW(file_uri_to_path("http://foo/bar"), std::invalid_argument);
-    BOOST_CHECK_THROW(file_uri_to_path("file://foo/bar"), std::invalid_argument);
+    CHECK_THROWS_AS(file_uri_to_path("http://foo/bar"), std::invalid_argument);
+    CHECK_THROWS_AS(file_uri_to_path("file://foo/bar"), std::invalid_argument);
 }

--- a/tests/utility_concurrency_unittest.cpp
+++ b/tests/utility_concurrency_unittest.cpp
@@ -1,8 +1,9 @@
-#define BOOST_TEST_MODULE cosim::utility unittests
+
 #include <cosim/utility/concurrency.hpp>
 #include <cosim/utility/filesystem.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <thread>
 
@@ -30,11 +31,11 @@ void test_locking(F1&& getMutex1, F2&& getMutex2, F3&& getMutex3)
         auto&& mutex3 = getMutex3();
 
         // Step 2
-        BOOST_TEST_REQUIRE(mutex3.try_lock());
-        BOOST_TEST_REQUIRE(!mutex1.try_lock());
-        BOOST_TEST_REQUIRE(!mutex1.try_lock_shared());
-        BOOST_TEST_REQUIRE(!mutex2.try_lock());
-        BOOST_TEST_REQUIRE(mutex2.try_lock_shared());
+        REQUIRE(mutex3.try_lock());
+        REQUIRE(!mutex1.try_lock());
+        REQUIRE(!mutex1.try_lock_shared());
+        REQUIRE(!mutex2.try_lock());
+        REQUIRE(mutex2.try_lock_shared());
         mutex3.unlock();
 
         // Wait for step 3 to complete
@@ -62,7 +63,7 @@ void test_locking(F1&& getMutex1, F2&& getMutex2, F3&& getMutex3)
     mutex3.unlock();
 }
 
-BOOST_AUTO_TEST_CASE(file_lock)
+TEST_CASE("file_lock")
 {
     const auto workDir = cosim::utility::temp_dir();
     test_locking(

--- a/tests/utility_filesystem_unittest.cpp
+++ b/tests/utility_filesystem_unittest.cpp
@@ -1,39 +1,40 @@
-#define BOOST_TEST_MODULE cosim::utility filesystem unittests
+
 #include <cosim/fs_portability.hpp>
 #include <cosim/utility/filesystem.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <utility>
 
 
-BOOST_AUTO_TEST_CASE(temp_dir)
+TEST_CASE("temp_dir")
 {
     namespace fs = cosim::filesystem;
     fs::path d;
     {
         auto tmp = cosim::utility::temp_dir();
         d = tmp.path();
-        BOOST_TEST_REQUIRE(!d.empty());
-        BOOST_TEST_REQUIRE(fs::exists(d));
-        BOOST_TEST(fs::is_directory(d));
-        BOOST_TEST(fs::is_empty(d));
+        REQUIRE(!d.empty());
+        REQUIRE(fs::exists(d));
+        CHECK(fs::is_directory(d));
+        CHECK(fs::is_empty(d));
 
         auto tmp2 = std::move(tmp);
-        BOOST_TEST(tmp.path().empty());
-        BOOST_TEST(tmp2.path() == d);
-        BOOST_TEST(fs::exists(d));
+        CHECK(tmp.path().empty());
+        CHECK(tmp2.path() == d);
+        CHECK(fs::exists(d));
 
         auto tmp3 = cosim::utility::temp_dir();
         const auto d3 = tmp3.path();
-        BOOST_TEST(fs::exists(d3));
-        BOOST_TEST_REQUIRE(!fs::equivalent(d, d3));
+        CHECK(fs::exists(d3));
+        REQUIRE(!fs::equivalent(d, d3));
 
         tmp3 = std::move(tmp2);
-        BOOST_TEST(tmp2.path().empty());
-        BOOST_TEST(!fs::exists(d3));
-        BOOST_TEST(tmp3.path() == d);
-        BOOST_TEST(fs::exists(d));
+        CHECK(tmp2.path().empty());
+        CHECK(!fs::exists(d3));
+        CHECK(tmp3.path() == d);
+        CHECK(fs::exists(d));
     }
-    BOOST_TEST(!fs::exists(d));
+    CHECK(!fs::exists(d));
 }

--- a/tests/utility_uuid_unittest.cpp
+++ b/tests/utility_uuid_unittest.cpp
@@ -1,12 +1,13 @@
-#define BOOST_TEST_MODULE cosim::utility uuid unittests
+
 #include <cosim/utility/uuid.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 
-BOOST_AUTO_TEST_CASE(random_uuid)
+TEST_CASE("random_uuid")
 {
     const auto u = cosim::utility::random_uuid();
-    BOOST_TEST(u.size() == 36);
-    BOOST_TEST(cosim::utility::random_uuid() != u);
+    CHECK(u.size() == 36);
+    CHECK(cosim::utility::random_uuid() != u);
 }

--- a/tests/utility_zip_unittest.cpp
+++ b/tests/utility_zip_unittest.cpp
@@ -1,15 +1,16 @@
-#define BOOST_TEST_MODULE cosim::utility::zip unittest
+
 #include <cosim/fs_portability.hpp>
 #include <cosim/utility/filesystem.hpp>
 #include <cosim/utility/zip.hpp>
 
-#include <boost/test/unit_test.hpp>
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
 
 #include <cstdlib>
 #include <system_error>
 
 
-BOOST_AUTO_TEST_CASE(zip_archive)
+TEST_CASE("zip_archive")
 {
     namespace ut = cosim::utility;
     namespace uz = cosim::utility::zip;
@@ -28,34 +29,34 @@ BOOST_AUTO_TEST_CASE(zip_archive)
 
     // Test setup
     const auto testDataDir = std::getenv("TEST_DATA_DIR");
-    BOOST_TEST_REQUIRE(!!testDataDir);
+    REQUIRE(!!testDataDir);
     const auto archivePath = fs::path(testDataDir) / "ziptest.zip";
 
     // Open archive
     auto archive = uz::archive(archivePath);
-    BOOST_TEST_REQUIRE(archive.is_open());
+    REQUIRE(archive.is_open());
 
     // Get entry info
-    BOOST_TEST(archive.entry_count() == archiveEntryCount);
+    CHECK(archive.entry_count() == archiveEntryCount);
     const auto dirIndex = archive.find_entry(dirName);
     const auto binIndex = archive.find_entry(binName);
     const auto txtIndex = archive.find_entry(txtName);
     const auto invIndex = archive.find_entry("no such entry");
-    BOOST_TEST_REQUIRE(dirIndex != uz::invalid_entry_index);
-    BOOST_TEST_REQUIRE(binIndex != uz::invalid_entry_index);
-    BOOST_TEST_REQUIRE(txtIndex != uz::invalid_entry_index);
-    BOOST_TEST(invIndex == uz::invalid_entry_index);
-    BOOST_TEST(binIndex != dirIndex);
-    BOOST_TEST(txtIndex != dirIndex);
-    BOOST_TEST(txtIndex != binIndex);
-    BOOST_TEST(archive.entry_name(dirIndex) == dirName);
-    BOOST_TEST(archive.entry_name(binIndex) == binName);
-    BOOST_TEST(archive.entry_name(txtIndex) == txtName);
-    BOOST_CHECK_THROW(archive.entry_name(invIndex), uz::error);
-    BOOST_TEST(archive.is_dir_entry(dirIndex));
-    BOOST_TEST(!archive.is_dir_entry(binIndex));
-    BOOST_TEST(!archive.is_dir_entry(txtIndex));
-    BOOST_CHECK_THROW(archive.is_dir_entry(invIndex), uz::error);
+    REQUIRE(dirIndex != uz::invalid_entry_index);
+    REQUIRE(binIndex != uz::invalid_entry_index);
+    REQUIRE(txtIndex != uz::invalid_entry_index);
+    CHECK(invIndex == uz::invalid_entry_index);
+    CHECK(binIndex != dirIndex);
+    CHECK(txtIndex != dirIndex);
+    CHECK(txtIndex != binIndex);
+    CHECK(archive.entry_name(dirIndex) == dirName);
+    CHECK(archive.entry_name(binIndex) == binName);
+    CHECK(archive.entry_name(txtIndex) == txtName);
+    CHECK_THROWS_AS(archive.entry_name(invIndex), uz::error);
+    CHECK(archive.is_dir_entry(dirIndex));
+    CHECK(!archive.is_dir_entry(binIndex));
+    CHECK(!archive.is_dir_entry(txtIndex));
+    CHECK_THROWS_AS(archive.is_dir_entry(invIndex), uz::error);
 
     // Extract entire archive
     {
@@ -64,15 +65,15 @@ BOOST_AUTO_TEST_CASE(zip_archive)
         const auto dirExtracted = tempDir.path() / dirName;
         const auto binExtracted = tempDir.path() / binName;
         const auto txtExtracted = tempDir.path() / txtName;
-        BOOST_TEST_REQUIRE(fs::exists(dirExtracted));
-        BOOST_TEST_REQUIRE(fs::exists(binExtracted));
-        BOOST_TEST_REQUIRE(fs::exists(txtExtracted));
-        BOOST_TEST(fs::is_directory(dirExtracted));
-        BOOST_TEST(fs::is_regular_file(binExtracted));
-        BOOST_TEST(fs::is_regular_file(txtExtracted));
-        BOOST_TEST(fs::file_size(binExtracted) == binSize);
-        BOOST_TEST(fs::file_size(txtExtracted) == txtSize);
-        BOOST_CHECK_THROW(archive.extract_file_to(binIndex, tempDir.path() / "nonexistent"), std::system_error);
+        REQUIRE(fs::exists(dirExtracted));
+        REQUIRE(fs::exists(binExtracted));
+        REQUIRE(fs::exists(txtExtracted));
+        CHECK(fs::is_directory(dirExtracted));
+        CHECK(fs::is_regular_file(binExtracted));
+        CHECK(fs::is_regular_file(txtExtracted));
+        CHECK(fs::file_size(binExtracted) == binSize);
+        CHECK(fs::file_size(txtExtracted) == txtSize);
+        CHECK_THROWS_AS(archive.extract_file_to(binIndex, tempDir.path() / "nonexistent"), std::system_error);
     }
 
     // Extract individual entries
@@ -80,15 +81,15 @@ BOOST_AUTO_TEST_CASE(zip_archive)
         ut::temp_dir tempDir;
         const auto binExtracted = archive.extract_file_to(binIndex, tempDir.path());
         const auto txtExtracted = archive.extract_file_to(txtIndex, tempDir.path());
-        BOOST_TEST(binExtracted.compare(tempDir.path() / binFilename) == 0);
-        BOOST_TEST(txtExtracted.compare(tempDir.path() / txtFilename) == 0);
-        BOOST_TEST(fs::file_size(binExtracted) == binSize);
-        BOOST_TEST(fs::file_size(txtExtracted) == txtSize);
-        BOOST_CHECK_THROW(archive.extract_file_to(invIndex, tempDir.path()), uz::error);
-        BOOST_CHECK_THROW(archive.extract_file_to(binIndex, tempDir.path() / "nonexistent"), std::system_error);
+        CHECK(binExtracted.compare(tempDir.path() / binFilename) == 0);
+        CHECK(txtExtracted.compare(tempDir.path() / txtFilename) == 0);
+        CHECK(fs::file_size(binExtracted) == binSize);
+        CHECK(fs::file_size(txtExtracted) == txtSize);
+        CHECK_THROWS_AS(archive.extract_file_to(invIndex, tempDir.path()), uz::error);
+        CHECK_THROWS_AS(archive.extract_file_to(binIndex, tempDir.path() / "nonexistent"), std::system_error);
     }
 
     archive.discard();
-    BOOST_TEST(!archive.is_open());
-    BOOST_CHECK_NO_THROW(archive.discard());
+    CHECK(!archive.is_open());
+    CHECK_NOTHROW(archive.discard());
 }


### PR DESCRIPTION
This PR replaces `boost::test` with `Catch2`. Catch2 is only downloaded if tests are enabled using CMake FetchContent.

The overall aim is to reduce the dependency on boost.  IMO, Catch2 to also an easier and prettier framework to use.

Also closes #702 (3.15 is needed for CMake dependency injection)

With this merged, all non-unittests test should be converted to proper unittests.