### PR TITLE
Disable gcc8

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [7, 8, 9]
+        compiler_version: [7, 9]
         compiler_libcxx: [libstdc++11]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']


### PR DESCRIPTION
Disable gcc8. 

Atleast until someone figures out how to fix the docker image.

Relates to #706 