### PR TITLE
Separate variable reference, type, causality into separate header lines 

### DIFF
--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -255,7 +255,7 @@ private:
         }
     }
 
-    void create_metadata_file(std::string time_str)
+    void create_metadata_file(const std::string& time_str)
     {
         std::ofstream metadata_fw;
         std::string filename;

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -75,8 +75,8 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
         if (recording_) {
             if (!fsw_.is_open()) {
-                create_log_file();
-                create_metadata_file();
+                auto dataFileName = create_log_file();
+                create_metadata_file(dataFileName);
             }
             if (timeStep % decimationFactor_ == 0) {
 
@@ -191,14 +191,16 @@ private:
         }
     }
 
-    void create_log_file()
+    std::string create_log_file()
     {
         std::string filename;
         std::stringstream ss;
+        std::string time_str;
+
         if (!timeStampedFileNames_) {
             filename = observable_->name().append(".csv");
         } else {
-            auto time_str = format_time(boost::posix_time::microsec_clock::local_time());
+            time_str = format_time(boost::posix_time::microsec_clock::local_time());
             filename = observable_->name().append("_").append(time_str).append(".csv");
         }
 
@@ -233,9 +235,11 @@ private:
         if (fsw_.is_open()) {
             fsw_ << ss.rdbuf();
         }
+
+        return time_str;
     }
 
-    void write_variable_metadata(std::stringstream& ss, std::vector<variable_description>& variables)
+    void write_variable_metadata(std::stringstream& ss, std::vector<variable_description>& variables) const
     {
         for (const auto& v : variables) {
             ss << "  - " << std::setw(keyWidth_) << "name:" << v.name << std::endl
@@ -251,7 +255,7 @@ private:
         }
     }
 
-    void create_metadata_file()
+    void create_metadata_file(std::string time_str)
     {
         std::ofstream metadata_fw;
         std::string filename;
@@ -260,7 +264,6 @@ private:
         if (!timeStampedFileNames_) {
             filename = observable_->name().append("_metadata.yaml");
         } else {
-            auto time_str = format_time(boost::posix_time::microsec_clock::local_time());
             filename = observable_->name().append("_").append(time_str).append("_metadata.yaml");
         }
 

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -223,54 +223,6 @@ private:
             ss << "," << vd.name;
         }
 
-        ss << std::endl << "#,#";
-
-        // Add variable references
-        for (const auto& vd : realVars_) {
-            ss << "," << vd.reference;
-        }
-        for (const auto& vd : intVars_) {
-            ss << "," << vd.reference;
-        }
-        for (const auto& vd : boolVars_) {
-            ss << "," << vd.reference;
-        }
-        for (const auto& vd : stringVars_) {
-            ss << "," << vd.reference;
-        }
-
-        ss << std::endl << "#,#";
-
-        // Add variables types
-        for (const auto& vd : realVars_) {
-            ss << "," << vd.type;
-        }
-        for (const auto& vd : intVars_) {
-            ss << "," << vd.type;
-        }
-        for (const auto& vd : boolVars_) {
-            ss << "," << vd.type;
-        }
-        for (const auto& vd : stringVars_) {
-            ss << "," << vd.type;
-        }
-
-        ss << std::endl << "#,#";
-
-        // Add variable causalities
-        for (const auto& vd : realVars_) {
-            ss << "," << vd.causality;
-        }
-        for (const auto& vd : intVars_) {
-            ss << "," << vd.causality;
-        }
-        for (const auto& vd : boolVars_) {
-            ss << "," << vd.causality;
-        }
-        for (const auto& vd : stringVars_) {
-            ss << "," << vd.causality;
-        }
-
         ss << std::endl;
 
         if (fsw_.is_open()) {

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -209,17 +209,66 @@ private:
 
         ss << "Time,StepCount";
 
+        // Add variable names
         for (const auto& vd : realVars_) {
-            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name;
         }
         for (const auto& vd : intVars_) {
-            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name;
         }
         for (const auto& vd : boolVars_) {
-            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name;
         }
         for (const auto& vd : stringVars_) {
-            ss << "," << vd.name << " [" << vd.reference << " " << vd.type << " " << vd.causality << "]";
+            ss << "," << vd.name;
+        }
+
+        ss << std::endl << "#,#";
+
+        // Add variable references
+        for (const auto& vd : realVars_) {
+            ss << "," << vd.reference;
+        }
+        for (const auto& vd : intVars_) {
+            ss << "," << vd.reference;
+        }
+        for (const auto& vd : boolVars_) {
+            ss << "," << vd.reference;
+        }
+        for (const auto& vd : stringVars_) {
+            ss << "," << vd.reference;
+        }
+
+        ss << std::endl << "#,#";
+
+        // Add variables types
+        for (const auto& vd : realVars_) {
+            ss << "," << vd.type;
+        }
+        for (const auto& vd : intVars_) {
+            ss << "," << vd.type;
+        }
+        for (const auto& vd : boolVars_) {
+            ss << "," << vd.type;
+        }
+        for (const auto& vd : stringVars_) {
+            ss << "," << vd.type;
+        }
+
+        ss << std::endl << "#,#";
+
+        // Add variable causalities
+        for (const auto& vd : realVars_) {
+            ss << "," << vd.causality;
+        }
+        for (const auto& vd : intVars_) {
+            ss << "," << vd.causality;
+        }
+        for (const auto& vd : boolVars_) {
+            ss << "," << vd.causality;
+        }
+        for (const auto& vd : stringVars_) {
+            ss << "," << vd.causality;
         }
 
         ss << std::endl;

--- a/tests/data/LogConfig.xml
+++ b/tests/data/LogConfig.xml
@@ -5,7 +5,7 @@
     <simulator name="slave" decimationFactor="20">
         <variable name="realOut"/>
         <variable name="intOut"/>
-        <variable name="booleanOut"/>
+        <!--variable name="booleanOut"/-->
         <variable name="stringOut"/>
     </simulator>
     <simulator name="slave2">

--- a/tests/file_observer_dynamic_logging_test.cpp
+++ b/tests/file_observer_dynamic_logging_test.cpp
@@ -7,6 +7,7 @@
 #include <cosim/observer/file_observer.hpp>
 
 #include <exception>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <thread>
@@ -74,7 +75,7 @@ int main()
         observer->stop_recording();
         REQUIRE(!observer->is_recording());
 
-        REQUIRE(filecount(logPath) == 2);
+        REQUIRE(filecount(logPath) == 4);
 
         remove_directory_contents(logPath);
         REQUIRE(filecount(logPath) == 0);
@@ -91,10 +92,12 @@ int main()
 
         execution.stop_simulation();
         t.get();
-        REQUIRE(filecount(logPath) == 4);
+
+        REQUIRE(filecount(logPath) == 8);
 
         // Test that files are released.
         remove_directory_contents(logPath);
+
         REQUIRE(filecount(logPath) == 0);
 
     } catch (const std::exception& e) {


### PR DESCRIPTION
This PR proposes to change the `variable_name [ref, type, causality]` pattern in the current file logging implementation to one new line for each. This might be easier to use when parsing the CSV files. 

In other words the values will now be logged starting from line 5, and the new CSV files look like this:

> 1. Time,StepCount,realOut,intOut,booleanOut,stringOut
> 2. #,#,0,0,0,0 
> 3. #,#,real,integer,boolean,string
> 4. #,#,output,output,output,output
> 5. 0,0,1.234,1,0,hello log
> 6. 0.1,1,1.234,1,0,hello log
> 