### PR TITLE
Preparing for 0.10.0 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### [v0.10.0] - 2022-12-02
 ##### Changed
-* GCC8 artifact builds have been removed, and GCC9 artifact builds added. GCC7 is still supported.
+* GCC7 and GCC8 artifact builds have been removed, and GCC9 artifact builds added. This is currently the only supported GCC version.
 * The file observer is now programmatically configurable, and there is no longer a need for clients to create a separate `LogConfig.xml` file upfront to specify it's configuration.
 * The file observer no longer outputs headers as `variable name [reference, type, causality].` Instead only the variable name is output, and the extra data about each variable and the model itself is output in a separate metadata file, in YAML format. This will have the same filename as the CSV file with the simulation data, including the timestamp, with `_metadata` at the end.
-* Using `find_variable` is now exceptional, returning an optional null value, if the desired variable description can't be found.
+* Using `find_variable` no longer throws an exception, but rather returns an optional value, which may be empty if the variable could not be found.
+* Update to proxyfmu 0.2.9.
 ##### Added 
 * An asynchronous version of `simulate_until` is now available through the `execution` interface. This accepts
   an optional end time parameter and launches the execution in a new thread.
 * Support has been added for optionally specifying simulation end time (where only start time was supported) in `OspSystemStructure.xml`. If specified, end time will also be parsed and made available in the simulation configuration.
-##### Fixed 
-* Update to proxyfmu 0.2.9
+##### Fixed
 
 ### [v0.9.0] – 2022-04-05
 ##### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to libcosim will be documented in this file. This includes n
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+### [v0.10.0] - 2022-12-02
+##### Changed
+* GCC8 artifact builds have been removed, and GCC9 artifact builds added. GCC7 is still supported.
+* The file observer is now programmatically configurable, and there is no longer a need for clients to create a separate `LogConfig.xml` file upfront to specify it's configuration.
+* The file observer no longer outputs headers as `variable name [reference, type, causality].` Instead only the variable name is output, and the extra data about each variable and the model itself is output in a separate metadata file, in YAML format. This will have the same filename as the CSV file with the simulation data, including the timestamp, with `_metadata` at the end.
+* Using `find_variable` is now exceptional, returning an optional null value, if the desired variable description can't be found.
+##### Added 
+* An asynchronous version of `simulate_until` is now available through the `execution` interface. This accepts
+  an optional end time parameter and launches the execution in a new thread.
+* Support has been added for optionally specifying simulation end time (where only start time was supported) in `OspSystemStructure.xml`. If specified, end time will also be parsed and made available in the simulation configuration.
+##### Fixed 
+* Update to proxyfmu 0.2.9
+
 ### [v0.9.0] – 2022-04-05
 ##### Changed
 * Removed fibers to simplify code and increase simulation performance. Concurrency must now be implemented in the master 
@@ -160,7 +173,7 @@ algorithm, and `fixed_step_algorithm` has been modified to use a thread pool. ([
 * introducing`orchestration` interface for classes that resolve model URIs of one or more specific URI schemes ([PR#233](https://github.com/open-simulation-platform/cse-core/pull/233)) 
 * logging configuration ([PR#247](https://github.com/open-simulation-platform/cse-core/pull/247))
 * observers can observe string and boolean variables ([PR#257](https://github.com/open-simulation-platform/cse-core/pull/257))
-* can set arbitraty real time factor ([PR#261](https://github.com/open-simulation-platform/cse-core/pull/261))
+* can set arbitrary real time factor ([PR#261](https://github.com/open-simulation-platform/cse-core/pull/261))
 * improved error reporting
    
 ##### Fixed
@@ -193,3 +206,4 @@ First OSP JIP partner release
 [v0.8.2]: https://github.com/open-simulation-platform/cse-core/compare/v0.8.1...v0.8.2
 [v0.8.3]: https://github.com/open-simulation-platform/cse-core/compare/v0.8.2...v0.8.3
 [v0.9.0]: https://github.com/open-simulation-platform/cse-core/compare/v0.8.3...v0.9.0
+[v0.10.0]: https://github.com/open-simulation-platform/cse-core/compare/v0.9.0...v0.10.0


### PR DESCRIPTION
Seems we are now ready to release! 

Please review the changelog updates. I'll proceed with the release once this is approved. 

One question about release:  in order to push a tagged artifact to JFrog, the easiest way is to tag manually with Git as 0.10.0, and push it? From reading the GitHub Action scripts, that seems to be what's going on. 

```
VERSION="v$(<version.txt)"
if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"
```

So if I have it right it'll go something like this; merge this, tag master as 0.10.0, force push version.txt with 0.10.0 to master, and new 0.10.0 release artifacts should be built and uploaded to stable channel? Please do correct me if I'm wrong ... :) 
