### PR TITLE
Update proxyfmu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,6 @@ set(LIBCOSIM_EXPORT_TARGET "${PROJECT_NAME}-targets")
 
 if(LIBCOSIM_USING_CONAN)
 
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
-    list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
-
     if(NOT LIBCOSIM_USING_CONAN_AUTO_CONFIG OR CONAN_EXPORTED)
         # Opting for manual invocation of conan install prior to loading CMake
         # or conan create has been invoked, setting CONAN_EXPORTED.

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class LibcosimConan(ConanFile):
         "revision": "auto"
     }
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package", "virtualrunenv"
+    generators = "cmake", "virtualrunenv"
     requires = (
         "boost/1.71.0",
         "fmilibrary/2.3",
@@ -53,7 +53,7 @@ class LibcosimConan(ConanFile):
 
     def requirements(self):
         if self.options.proxyfmu:
-            self.requires("proxyfmu/0.2.9@osp/stable")
+            self.requires("proxyfmu/0.3.0@osp/testing-undo_cmake_find_package")
 
     def imports(self):
         binDir = os.path.join("output", str(self.settings.build_type).lower(), "bin")

--- a/conanfile.py
+++ b/conanfile.py
@@ -53,7 +53,7 @@ class LibcosimConan(ConanFile):
 
     def requirements(self):
         if self.options.proxyfmu:
-            self.requires("proxyfmu/0.3.0@osp/testing-undo_cmake_find_package")
+            self.requires("proxyfmu/0.3.0@osp/stable")
 
     def imports(self):
         binDir = os.path.join("output", str(self.settings.build_type).lower(), "bin")


### PR DESCRIPTION
Undoes `cmake_find_package` conan generator.

Fixes downstream issues.

See https://github.com/open-simulation-platform/proxy-fmu/pull/83