### PR TITLE
Loosen causality checks for system_structure initial values

### DIFF
--- a/src/cosim/execution.cpp
+++ b/src/cosim/execution.cpp
@@ -538,14 +538,6 @@ entity_index_maps inject_system_structure(
                     " (only supported for simulator variables)");
         }
         const auto& varDesc = sys.get_variable_description(var);
-        if (varDesc.causality != variable_causality::parameter &&
-            varDesc.causality != variable_causality::input) {
-            throw error(
-                make_error_code(errc::invalid_system_structure),
-                "Cannot set initial value of variable " +
-                    to_text(var) +
-                    " (only supported for parameters and inputs)");
-        }
         const auto simIdx = indexMaps.simulators.at(var.entity_name);
         const auto valRef = varDesc.reference;
         std::visit(

--- a/src/cosim/system_structure.cpp
+++ b/src/cosim/system_structure.cpp
@@ -391,6 +391,11 @@ void add_variable_value(
     scalar_value value)
 {
     const auto& varDescription = systemStructure.get_variable_description(variable);
+    if (varDescription.variability == variable_variability::constant) {
+        std::ostringstream msg;
+        msg << "Cannot modify value of constant variable '" << variable << "'";
+        throw error(make_error_code(errc::invalid_system_structure), msg.str());
+    }
     if (std::string e; !is_valid_variable_value(varDescription, value, &e)) {
         std::ostringstream msg;
         msg << "Invalid value for variable '" << variable << "': " << e;


### PR DESCRIPTION
This removes the overly strict, non-conformant causality check in `inject_system_structure()` to fix #742. As a small compensation, I've added a new variability check in `add_variable_value()`. This prevents something which is *never* allowed, namely to modify a `constant` variable, and it does so at an earlier stage than `inject_system_structure()`.