### PR TITLE
Conan: Use transitive_libs=True for Boost

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -43,9 +43,9 @@ class LibcosimConan(ConanFile):
         self.requires("ms-gsl/[>=3 <5]", transitive_headers=True)
         if self.options.proxyfmu:
             self.requires("proxyfmu/0.3.2@osp/stable")
-            self.requires("boost/[~1.81]", transitive_headers=True) # Required by Thrift
+            self.requires("boost/[~1.81]", transitive_headers=True, transitive_libs=True) # Required by Thrift
         else:
-            self.requires("boost/[>=1.71]", transitive_headers=True)
+            self.requires("boost/[>=1.71]", transitive_headers=True, transitive_libs=True)
         self.requires("yaml-cpp/[~0.8]")
         self.requires("xerces-c/[~3.2]")
 


### PR DESCRIPTION
Since we use Boost in some libcosim headers, and more specifically Boost libraries that have binary components (i.e., are not header-only), such as Boost.Log, then we need to specify the `transitive_libs=True` trait when listing the requirement. Otherwise, client code won't have access to those binary components for linking.

Thanks to @davidhjp01 for [pointing out](https://github.com/open-simulation-platform/libcosim/pull/747#discussion_r1417957294) the issue.