### PR TITLE
Allow use of UNC paths on Windows

### DIFF
--- a/src/cosim/orchestration.cpp
+++ b/src/cosim/orchestration.cpp
@@ -118,10 +118,12 @@ std::shared_ptr<model> fmu_file_uri_sub_resolver::lookup_model(const uri& modelU
 {
     assert(modelUri.scheme().has_value());
     if (*modelUri.scheme() != "file") return nullptr;
+#ifndef _WIN32
     if (modelUri.authority().has_value() &&
         !(modelUri.authority()->empty() || *modelUri.authority() == "localhost")) {
         return nullptr;
     }
+#endif
     if (modelUri.query().has_value() || modelUri.fragment().has_value()) {
         BOOST_LOG_SEV(log::logger(), log::warning)
             << "Query and/or fragment component(s) in a file:// URI were ignored: "

--- a/src/cosim/uri.cpp
+++ b/src/cosim/uri.cpp
@@ -529,9 +529,6 @@ uri path_to_file_uri(const cosim::filesystem::path& path)
 cosim::filesystem::path file_uri_to_path(const uri& fileUri)
 {
     COSIM_INPUT_CHECK(fileUri.scheme() && *fileUri.scheme() == "file");
-    COSIM_INPUT_CHECK(fileUri.authority() &&
-        (fileUri.authority()->empty() || *fileUri.authority() == "localhost"));
-
 #ifdef _WIN32
     // Windows has some special rules for file URIs; better use the built-in
     // functions.
@@ -554,6 +551,8 @@ cosim::filesystem::path file_uri_to_path(const uri& fileUri)
     return cosim::filesystem::path(pathBuffer, pathBuffer + pathSize);
 
 #else
+    COSIM_INPUT_CHECK(fileUri.authority() &&
+        (fileUri.authority()->empty() || *fileUri.authority() == "localhost"));
     return cosim::filesystem::path(percent_decode(fileUri.path()));
 #endif
 }

--- a/tests/uri_unittest.cpp
+++ b/tests/uri_unittest.cpp
@@ -205,6 +205,7 @@ BOOST_AUTO_TEST_CASE(file_uri_conversions)
     BOOST_TEST(path_to_file_uri("\\foo bar\\baz") == "file:///foo%20bar/baz");
     BOOST_TEST(path_to_file_uri("/foo bar/baz") == "file:///foo%20bar/baz");
     BOOST_TEST(path_to_file_uri("c:\\foo bar\\baz") == "file:///c:/foo%20bar/baz");
+    BOOST_TEST(path_to_file_uri("\\\\foo\\bar\\baz") == "file://foo/bar/baz");
 #endif
 
     // From URI to path
@@ -213,12 +214,13 @@ BOOST_AUTO_TEST_CASE(file_uri_conversions)
     BOOST_TEST(file_uri_to_path("file:///c:/foo%20bar/baz") == "c:\\foo bar\\baz");
     BOOST_TEST(file_uri_to_path("file://localhost/foo%20bar/baz") == "\\foo bar\\baz");
     BOOST_TEST(file_uri_to_path("file://localhost/c:/foo%20bar/baz") == "c:\\foo bar\\baz");
+    BOOST_TEST(file_uri_to_path("file://foo/bar/baz") == "\\\\foo\\bar\\baz");
 #else
     BOOST_TEST(file_uri_to_path("file:///foo%20bar/baz") == "/foo bar/baz");
     BOOST_TEST(file_uri_to_path("file:///c:/foo%20bar/baz") == "/c:/foo bar/baz");
     BOOST_TEST(file_uri_to_path("file://localhost/foo%20bar/baz") == "/foo bar/baz");
     BOOST_TEST(file_uri_to_path("file://localhost/c:/foo%20bar/baz") == "/c:/foo bar/baz");
+    BOOST_CHECK_THROW(file_uri_to_path("file://foo/bar"), std::invalid_argument);
 #endif
     BOOST_CHECK_THROW(file_uri_to_path("http://foo/bar"), std::invalid_argument);
-    BOOST_CHECK_THROW(file_uri_to_path("file://foo/bar"), std::invalid_argument);
 }


### PR DESCRIPTION
This fixes issue #619.

File URIs generally have the form `file://hostname/path/to/file`. When `hostname` is not `localhost` (nor empty) the file URI scheme leaves the file access mechanism unspecified. However, on Windows, such URIs are commonly interpreted as UNC paths, so in this case it would be `\\hostname\path\to\file`. This PR simply enables us to take advantage of this interpretation, which is built into the Windows API functions we already use.