### PR TITLE
Transfer variables after setup and initialisation

### DIFF
--- a/src/cosim/algorithm/fixed_step_algorithm.cpp
+++ b/src/cosim/algorithm/fixed_step_algorithm.cpp
@@ -168,15 +168,7 @@ public:
                 });
             }
             pool_.wait_for_tasks_to_finish();
-
-            for (const auto& s : simulators_) {
-                transfer_variables(s.second.outgoingSimConnections);
-                transfer_variables(s.second.outgoingFunConnections);
-            }
-            for (const auto& f : functions_) {
-                f.second.fun->calculate();
-                transfer_variables(f.second.outgoingSimConnections);
-            }
+            calculate_and_transfer();
         }
 
         for (auto& s : simulators_) {
@@ -185,6 +177,7 @@ public:
             });
         }
         pool_.wait_for_tasks_to_finish();
+        calculate_and_transfer();
     }
 
     std::pair<duration, std::unordered_set<simulator_index>> do_step(time_point currentT)
@@ -193,8 +186,8 @@ public:
         bool failed = false;
         std::stringstream errMessages;
         std::unordered_set<simulator_index> finished;
-        // Initiate simulator time steps.
 
+        // Initiate simulator time steps.
         for (auto& s : simulators_) {
             auto& info = s.second;
             if (stepCounter_ % info.decimationFactor == 0) {
@@ -220,37 +213,20 @@ public:
                 });
             }
         }
-
         ++stepCounter_;
-
         for (auto& [idx, info] : simulators_) {
             if (stepCounter_ % info.decimationFactor == 0) {
                 finished.insert(idx);
             }
         }
 
+        // Wait for all time steps to finish, then calculate functions and
+        // transfer variables.
         pool_.wait_for_tasks_to_finish();
-
         if (failed) {
             throw error(make_error_code(errc::simulation_error), errMessages.str());
         }
-
-        // Transfer the outputs from simulators that have finished their
-        // individual time steps within this co-simulation time step.
-        for (auto simIndex : finished) {
-            auto& simInfo = simulators_.at(simIndex);
-            transfer_variables(simInfo.outgoingSimConnections);
-            transfer_variables(simInfo.outgoingFunConnections);
-        }
-
-        // Calculate functions and transfer their outputs to simulators.
-        for (const auto& f : functions_) {
-            const auto& info = f.second;
-            if (stepCounter_ % info.decimationFactor == 0) {
-                info.fun->calculate();
-                transfer_variables(info.outgoingSimConnections);
-            }
-        }
+        calculate_and_transfer();
 
         return {baseStepSize_, std::move(finished)};
     }
@@ -328,6 +304,25 @@ private:
                     current,
                     simulators_.at(connection.target.simulator).decimationFactor);
             });
+    }
+
+    void calculate_and_transfer()
+    {
+        // Transfer the outputs from simulators that have finished their
+        // individual time steps within the current co-simulation time step.
+        for (const auto& s : simulators_) {
+            if (stepCounter_ % s.second.decimationFactor == 0) {
+                transfer_variables(s.second.outgoingSimConnections);
+                transfer_variables(s.second.outgoingFunConnections);
+            }
+        }
+        // Calculate functions and transfer their outputs to simulators.
+        for (const auto& f : functions_) {
+            if (stepCounter_ % f.second.decimationFactor == 0) {
+                f.second.fun->calculate();
+                transfer_variables(f.second.outgoingSimConnections);
+            }
+        }
     }
 
     void transfer_variables(const std::vector<connection_ss>& connections)

--- a/src/cosim/slave_simulator.cpp
+++ b/src/cosim/slave_simulator.cpp
@@ -490,7 +490,8 @@ public:
         std::optional<time_point> stopTime,
         std::optional<double> relativeTolerance)
     {
-        return slave_->setup(startTime, stopTime, relativeTolerance);
+        slave_->setup(startTime, stopTime, relativeTolerance);
+        get_variables(duration::zero());
     }
 
     void do_iteration()
@@ -501,6 +502,7 @@ public:
 
     void start_simulation()
     {
+        set_variables(duration::zero());
         slave_->start_simulation();
         get_variables(duration::zero());
     }


### PR DESCRIPTION
`fixed_step_algorithm::initialize()` ends by calling `simulator::start_simulation()`, which, for an FMI 2.0 FMU ends up calling `fmi2ExitInitializationMode()`. This function is not prohibited from modifying variable values, which means that we must assume that it does. Previously we did not, and this has led to issue #609, which to me looks like a pretty severe correctness issue. Here, I've added `get_variables()` and `set_variables()` calls at additional points in the call sequence of a `slave_simulator()` where variable values may have changed, and I've added a variable transfer at the end of `fixed_step_algorithm::initialize()`.

I've run the [quarter-truck](https://github.com/open-simulation-platform/demo-cases/tree/master/quarter-truck) case to verify that these changes actually do fix #609:

![issue-609-before-after](https://github.com/open-simulation-platform/libcosim/assets/214562/00f48b8b-59e1-4bdb-9268-fadffae2d093)