### PR TITLE
Controlling fixed precision for logging float point values

### DIFF
--- a/include/cosim/observer/file_observer.hpp
+++ b/include/cosim/observer/file_observer.hpp
@@ -23,6 +23,7 @@ namespace cosim
 
 class file_observer;
 
+
 /**
  * Configuration options for file_observer.
  */
@@ -88,9 +89,21 @@ public:
      */
     static file_observer_config parse(const filesystem::path& configPath);
 
+    /**
+     * Sets fixed precision value for floating point numbers
+     *
+     * \param precision the number of digits after the decimal point
+     */
+    void fixed_precision(const int precision)
+    {
+        precision_ = precision;
+    }
+
 private:
     bool timeStampedFileNames_{true};
     size_t defaultDecimationFactor_{1};
+    int precision_{-1};
+
     std::unordered_map<std::string, std::pair<size_t, std::vector<std::string>>> variablesToLog_;
 
     [[nodiscard]] bool should_log_simulator(const std::string& name) const

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -139,7 +139,6 @@ public:
 
 private:
     int keyWidth_ = 14;
-    int precision_ = -1;
 
     template<typename T>
     void write(const std::vector<T>& values, std::stringstream& ss)
@@ -357,6 +356,7 @@ private:
     std::atomic<bool> recording_ = true;
     std::mutex mutex_;
     bool timeStampedFileNames_ = true;
+    int precision_ = -1;
 };
 
 file_observer::file_observer(const cosim::filesystem::path& logDir, std::optional<file_observer_config> config)


### PR DESCRIPTION
CSV files printed from `file_observer` does not include enough decimal places in case for logging latitude and longitude values for a ship vessel. Added a method `cosim::file_observer::file_observer_config::fixed_precision(const int)` to specify fixed precision value for `file_observer`.