### PR TITLE
Enable saving and restoring full simulation state

### DIFF
--- a/include/cosim/algorithm/fixed_step_algorithm.hpp
+++ b/include/cosim/algorithm/fixed_step_algorithm.hpp
@@ -56,6 +56,8 @@ public:
     void setup(time_point startTime, std::optional<time_point> stopTime) override;
     void initialize() override;
     std::pair<duration, std::unordered_set<simulator_index>> do_step(time_point currentT) override;
+    serialization::node export_current_state() const override;
+    void import_state(const serialization::node& exportedState) override;
 
     /**
      * Sets step size decimation factor for a simulator.

--- a/include/cosim/observer/file_observer.hpp
+++ b/include/cosim/observer/file_observer.hpp
@@ -170,6 +170,8 @@ public:
         duration lastStepSize,
         time_point currentTime) override;
 
+    void state_restored(step_number currentStep, time_point currentTime) override;
+
     cosim::filesystem::path get_log_path();
 
     ~file_observer() override;

--- a/include/cosim/observer/last_value_observer.hpp
+++ b/include/cosim/observer/last_value_observer.hpp
@@ -56,6 +56,8 @@ public:
         duration lastStepSize,
         time_point currentTime) override;
 
+    void state_restored(step_number currentStep, time_point currentTime) override;
+
     void get_real(
         simulator_index sim,
         gsl::span<const value_reference> variables,

--- a/include/cosim/observer/observer.hpp
+++ b/include/cosim/observer/observer.hpp
@@ -115,7 +115,15 @@ public:
         duration lastStepSize,
         time_point currentTime) = 0;
 
-    /// The simulation was restored to a previously saved state.
+    /**
+     *  The simulation was restored to a previously saved state.
+     *
+     *  Note that observers which support this feature must be able to
+     *  reconstruct their internal state using information which is available
+     *  through the `observable` objects they have been given access to.  For
+     *  observers where this is not the case, this function should throw
+     *  `cosim::error` with error code `cosim::errc::unsupported_feature`.
+     */
     virtual void state_restored(step_number currentStep, time_point currentTime) = 0;
 
     virtual ~observer() noexcept { }

--- a/include/cosim/observer/observer.hpp
+++ b/include/cosim/observer/observer.hpp
@@ -115,6 +115,9 @@ public:
         duration lastStepSize,
         time_point currentTime) = 0;
 
+    /// The simulation was restored to a previously saved state.
+    virtual void state_restored(step_number currentStep, time_point currentTime) = 0;
+
     virtual ~observer() noexcept { }
 };
 

--- a/include/cosim/observer/time_series_observer.hpp
+++ b/include/cosim/observer/time_series_observer.hpp
@@ -65,6 +65,8 @@ public:
         duration lastStepSize,
         time_point currentTime) override;
 
+    void state_restored(step_number currentStep, time_point currentTime) override;
+
     /**
      * Start observing a variable.
      *

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -429,6 +429,15 @@ void file_observer::simulator_step_complete(simulator_index index, step_number l
     }
 }
 
+void file_observer::state_restored(step_number currentStep, time_point currentTime)
+{
+    if (recording_) {
+        for (const auto& entry : valueWriters_) {
+            entry.second->observe(currentStep, currentTime);
+        }
+    }
+}
+
 cosim::filesystem::path file_observer::get_log_path()
 {
     return logDir_;

--- a/src/cosim/observer/last_value_observer.cpp
+++ b/src/cosim/observer/last_value_observer.cpp
@@ -61,6 +61,15 @@ void last_value_observer::simulator_step_complete(
     valueProviders_.at(index)->observe();
 }
 
+void last_value_observer::state_restored(
+    step_number /*currentStep*/,
+    time_point /*currentTime*/)
+{
+    for (const auto& entry : valueProviders_) {
+        entry.second->observe();
+    }
+}
+
 void last_value_observer::get_real(
     simulator_index sim,
     gsl::span<const value_reference> variables,

--- a/src/cosim/observer/time_series_observer.cpp
+++ b/src/cosim/observer/time_series_observer.cpp
@@ -262,6 +262,14 @@ void time_series_observer::simulator_step_complete(
     slaveObservers_.at(index)->observe(lastStep, currentTime);
 }
 
+void time_series_observer::state_restored(
+    step_number currentStep, time_point currentTime)
+{
+    for (const auto& entry : slaveObservers_) {
+        entry.second->observe(currentStep, currentTime);
+    }
+}
+
 void time_series_observer::start_observing(variable_id id)
 {
     slaveObservers_.at(id.simulator)->start_observing(id.type, id.reference);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     "multi_fixed_step_algorithm_test"
     "osp_config_parser_test"
     "ramp_modifier_test"
+    "save_state_test"
     "time_series_observer_test"
     "trend_buffer_test"
     "scenario_manager_test"

--- a/tests/mock_slave.hpp
+++ b/tests/mock_slave.hpp
@@ -252,7 +252,7 @@ public:
         es.put("realIn", ss.realIn);
         es.put("intIn", ss.intIn);
         es.put("boolIn", ss.boolIn);
-        es.put("strginIn", ss.stringIn);
+        es.put("stringIn", ss.stringIn);
         return es;
     }
 


### PR DESCRIPTION
This closes #768. Some changes may warrant a bit of extra explanation:

**`execution` and `algorithm`:** I have taken one step towards prohibiting adding/removing sub-simulators after the co-simulation has begun, as decided in #771.  In particular, I've added the `execution::initialize()` function, which marks the point where such changes are no longer allowed.  (This is a backwards-compatible change, because it gets automatically called by `execution::step()` if it hasn't been called manually.)

**`slave_simulator`**: The changes in `slave_simulator.cpp` really ought to have been included in #769. Unfortunately, I didn't realise they were necessary before it was all put into the context of saving algorithm and execution state.  Basically, I thought I could get away with just saving each FMU's internal state, but it turns out that we also need to save the `slave_simulator` "get" and "set" caches.

(For those interested in the nitty-gritties, this is due to some subtleties regarding exactly when the cache values are set in the course of a co-simulation, relative to when the values are passed to the FMU. At the end of an "algorithm step", the "set cache" is out of sync with the FMUs input variables, and won't be synced before the next step. Simply performing an additional sync prior to saving the state is not sufficient, because that could have an effect on the FMUs output variables, thus invalidating the "get cache". That could in principle be updated too, but then the `slave_simulator` is in a whole different state from where it was when we started to save the state.)