### PR TITLE
Implement additional logconfig xml functionality

### DIFF
--- a/include/cosim/observer/file_observer.hpp
+++ b/include/cosim/observer/file_observer.hpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -567,7 +567,8 @@ file_observer_config file_observer_config::parse(const filesystem::path& configP
         boost::property_tree::xml_parser::no_comments | boost::property_tree::xml_parser::trim_whitespace);
 
     file_observer_config config;
-    for (const auto& simulator : ptree.get_child("simulators")) {
+    const auto simulators = ptree.get_child("simulators");
+    for (const auto& simulator : simulators) {
         if (simulator.first == "simulator") {
             const auto modelName = get_attribute<std::string>(simulator.second, "name");
             const auto decimationFactor = get_optional_attribute<size_t>(simulator.second, "decimationFactor");
@@ -580,6 +581,17 @@ file_observer_config file_observer_config::parse(const filesystem::path& configP
             }
             config.log_simulator_variables(modelName, variableNames, decimationFactor);
         }
+    }
+    if (const auto configuration = ptree.get_child("configuration")) {
+        const auto timestamps = get_optional_attribute<bool>(configuration, "timestampedFilenames");
+        if (timestamps) {
+            config.set_timestamped_filenames(*timestamps);
+        }
+        const auto precision = get_optional_attribute<size_t>(configuration, "floatingPointPrecision");
+        if (precision) {
+            config.fixed_precision(*precision);
+        }
+
     }
 
     return config;

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -582,12 +582,12 @@ file_observer_config file_observer_config::parse(const filesystem::path& configP
             config.log_simulator_variables(modelName, variableNames, decimationFactor);
         }
     }
-    if (const auto configuration = ptree.get_child("configuration")) {
-        const auto timestamps = get_optional_attribute<bool>(configuration, "timestampedFilenames");
+    if (const auto configuration = ptree.get_child_optional("configuration")) {
+        const auto timestamps = get_optional_attribute<bool>(*configuration, "timestampedFilenames");
         if (timestamps) {
             config.set_timestamped_filenames(*timestamps);
         }
-        const auto precision = get_optional_attribute<size_t>(configuration, "floatingPointPrecision");
+        const auto precision = get_optional_attribute<int>(*configuration, "floatingPointPrecision");
         if (precision) {
             config.fixed_precision(*precision);
         }

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -567,8 +567,7 @@ file_observer_config file_observer_config::parse(const filesystem::path& configP
         boost::property_tree::xml_parser::no_comments | boost::property_tree::xml_parser::trim_whitespace);
 
     file_observer_config config;
-    const auto simulators = ptree.get_child("simulators");
-    for (const auto& simulator : simulators) {
+    for (const auto& simulator : ptree.get_child("simulators")) {
         if (simulator.first == "simulator") {
             const auto modelName = get_attribute<std::string>(simulator.second, "name");
             const auto decimationFactor = get_optional_attribute<size_t>(simulator.second, "decimationFactor");
@@ -583,15 +582,12 @@ file_observer_config file_observer_config::parse(const filesystem::path& configP
         }
     }
     if (const auto configuration = ptree.get_child_optional("configuration")) {
-        const auto timestamps = get_optional_attribute<bool>(*configuration, "timestampedFilenames");
-        if (timestamps) {
+        if (const auto timestamps = get_optional_attribute<bool>(*configuration, "timestampedFilenames")) {
             config.set_timestamped_filenames(*timestamps);
         }
-        const auto precision = get_optional_attribute<int>(*configuration, "floatingPointPrecision");
-        if (precision) {
+        if (const auto precision = get_optional_attribute<int>(*configuration, "floatingPointPrecision")) {
             config.fixed_precision(*precision);
         }
-
     }
 
     return config;

--- a/tests/data/LogConfig.xml
+++ b/tests/data/LogConfig.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
+<configuration timestampedFilenames="false" floatingPointPrecision="1"/>
 <simulators xmlns="http://opensimulationplatform.com/LogConfig">
 
     <simulator name="slave" decimationFactor="20">

--- a/tests/file_observer_logging_from_config_test.cpp
+++ b/tests/file_observer_logging_from_config_test.cpp
@@ -64,6 +64,9 @@ int main()
         auto simResult = execution.simulate_until(endTime);
         REQUIRE(simResult);
 
+        REQUIRE(cosim::filesystem::exists(cosim::filesystem::path(csvPath / "slave.csv")));
+        REQUIRE(cosim::filesystem::exists(cosim::filesystem::path(csvPath / "slave2.csv")));
+
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;
         return 1;


### PR DESCRIPTION
Closes #776 

It is now possible to configure timestamped log file names and floating point precision via LogConfig.xml