### PR TITLE
Don't crash if FMUs log with category=NULL

### DIFF
--- a/src/cosim/fmi/v1/fmu.cpp
+++ b/src/cosim/fmi/v1/fmu.cpp
@@ -236,7 +236,8 @@ void log_message(
             break;
     }
     BOOST_LOG_SEV(log::logger(), logLevel)
-        << "[FMI status=" << statusName << ", category=" << category << "] "
+        << "[FMI status=" << statusName
+        << ", category=" << (category ? category : "") << "] "
         << msgBuffer.data();
 
     g_logMutex.lock();

--- a/src/cosim/fmi/v2/fmu.cpp
+++ b/src/cosim/fmi/v2/fmu.cpp
@@ -243,7 +243,8 @@ void log_message(
             break;
     }
     BOOST_LOG_SEV(log::logger(), logLevel)
-        << "[FMI status=" << statusName << ", category=" << category << "] "
+        << "[FMI status=" << statusName
+        << ", category=" << (category ? category : "") << "] "
         << msgBuffer.data();
 
     g_logMutex.lock();


### PR DESCRIPTION
This fixes #796.

We don't have any straightforward way to test this right now, since our test FMUs aren't easily modifiable. Perhaps @SSkjong, who discovered the issue, can test with the FMU that triggered it?