### PR TITLE
Use GCC image for Linux builds and simplify workflow

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update
-          apt-get install -y pipx cmake doxygen
+          apt-get install -y pipx doxygen
           pipx install conan
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Configure Conan

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -6,37 +6,37 @@ on: [push, workflow_dispatch]
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        compiler_version: [9]
+        compiler_version: [14]
         option_proxyfmu: ['proxyfmu=True', 'proxyfmu=False']
         option_shared: ['shared=True', 'shared=False']
+    runs-on: ubuntu-latest
+    container:
+      image: gcc:${{ matrix.compiler_version }}
+    env:
+      CONAN_LOGIN_USERNAME_OSP: ${{ secrets.osp_artifactory_usr }}
+      CONAN_PASSWORD_OSP: ${{ secrets.osp_artifactory_pwd }}
+      LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD: 1
     timeout-minutes: 35
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Generate Dockerfile
+      - uses: actions/checkout@v6
+      - name: Install prerequisites
         run: |
-          mkdir /tmp/osp-builder-docker
-          cat <<'EOF' >/tmp/osp-builder-docker/Dockerfile
-          FROM conanio/gcc${{ matrix.compiler_version }}-ubuntu16.04
-          ENV CONAN_LOGIN_USERNAME_OSP=${{ secrets.osp_artifactory_usr }}
-          ENV CONAN_PASSWORD_OSP=${{ secrets.osp_artifactory_pwd }}
-          ENV LIBCOSIM_RUN_TESTS_ON_CONAN_BUILD=1
-          COPY entrypoint.sh /
-          ENTRYPOINT /entrypoint.sh
-          EOF
-      - name: Generate entrypoint.sh
+          apt-get update
+          apt-get install -y pipx cmake doxygen
+          pipx install conan
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Configure Conan
         run: |
-          cat <<'EOF' >/tmp/osp-builder-docker/entrypoint.sh
-          #!/bin/bash -v
-          set -eu
-          cd /mnt/source
-          pip install conan --upgrade
-          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force
+          conan profile detect
+          conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local
+      - name: Build package
+        shell: bash
+        run: |
           REFNAME="${GITHUB_REF#refs/*/}"
           VERSION="v$(<version.txt)"
           if [[ $GITHUB_REF == refs/tags/* ]] && [[ $REFNAME == $VERSION ]]; then CHANNEL="stable"
@@ -47,23 +47,17 @@ jobs:
           fi
           conan create \
             --settings="build_type=${{ matrix.build_type }}" \
-            --options="${{ matrix.option_proxyfmu }}" \
-            --options="${{ matrix.option_shared }}" \
+            --options="&:${{ matrix.option_proxyfmu }}" \
+            --options="*:${{ matrix.option_shared }}" \
             --update \
             --build=missing \
             --build=b2/* \
             --user=osp \
             --channel="${CHANNEL}" \
             .
-          conan upload --confirm --remote=osp '*'
-          EOF
-          chmod 0755 /tmp/osp-builder-docker/entrypoint.sh
-      - name: Build Docker image
-        run:  docker build -t osp-builder /tmp/osp-builder-docker/
-      - name: Build cosim
+      - name: Upload package
         run: |
-          docker run --rm --env GITHUB_REF="$GITHUB_REF" -v $(pwd):/mnt/source:ro osp-builder
-
+          conan upload --confirm --remote=osp '*'
 
   windows:
     name: Windows
@@ -82,7 +76,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install prerequisites
         run: |
           pip3 install --upgrade setuptools pip
@@ -104,8 +98,8 @@ jobs:
           fi
           conan create \
             --settings="build_type=${{ matrix.build_type }}" \
-            --options="${{ matrix.option_proxyfmu }}" \
-            --options="${{ matrix.option_shared }}" \
+            --options="&:${{ matrix.option_proxyfmu }}" \
+            --options="*:${{ matrix.option_shared }}" \
             --update \
             --build=missing \
             --user=osp \

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,17 +40,17 @@ class LibcosimConan(ConanFile):
 
     # Dependencies/requirements
     def requirements(self):
-        self.tool_requires("cmake/[>=3.19]")
+        self.tool_requires("cmake/[>=4.0]")
         self.requires("fmilibrary/[~2.3]")
         self.requires("libcbor/0.11.0")
         self.requires("libzip/[~1.11]")
         self.requires("ms-gsl/[>=3 <5]", transitive_headers=True)
         self.requires("boost/[~1.85]", transitive_headers=True, transitive_libs=True)  # Required by Thrift
         if self.options.proxyfmu:
-            self.requires("proxyfmu/0.4.1@osp/stable",
+            self.requires("proxyfmu/0.4.2@osp/stable",
                           transitive_headers=True,
                           transitive_libs=True)
-        self.requires("yaml-cpp/[~0.8]")
+        self.requires("yaml-cpp/[~0.9]")
         self.requires("xerces-c/[~3.2]")
 
     # Exports
@@ -127,3 +127,4 @@ class LibcosimConan(ConanFile):
             "true",
             "1",
         )
+

--- a/src/cosim/observer/file_observer.cpp
+++ b/src/cosim/observer/file_observer.cpp
@@ -217,7 +217,7 @@ private:
 
         if (fsw_.fail()) {
             std::stringstream error;
-            error << "Failed to open log file stream: " << filePath.c_str();
+            error << "Failed to open log file stream: " << filePath.string();
             throw std::runtime_error(error.str());
         }
 
@@ -279,7 +279,7 @@ private:
 
         if (fsw_.fail()) {
             std::stringstream error;
-            error << "Failed to open log metadata file stream: " << filePath.c_str();
+            error << "Failed to open log metadata file stream: " << filePath.string();
             throw std::runtime_error(error.str());
         }
 


### PR DESCRIPTION
This fixes #800 by making changes to the Conan+Linux CI workflow. The official Conan Center docker image we were using has now been deprecated (all of them have), so I have switched to using the official GCC image instead. This required a GCC version upgrade. The oldest supported version is 12, but I went with 14 so we can stay on the same version for a while. (GCC 15 is the newest, at the time of writing.)

I also replaced the roundabout process we had of generating our own Docker image to using Github Actions' built-in facilities for choosing an image.

This also fixes #798 by updating the Conan options syntax for both Linux and Windows workflows.